### PR TITLE
Redo small screen HTML adjustments

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/templates/components/objects/dataview.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/components/objects/dataview.html
@@ -67,7 +67,7 @@
                         trigger_icon_class="fa fa-filter"
                         trigger_button_class="btn-secondary"
                         trigger_class="w-full justify-center gap-2"
-                        wrapper_class="w-full"
+                        wrapper_class="w-full sm:w-auto"
                         size="sm"
                         width="w-128"
                         >
@@ -82,7 +82,7 @@
                                         {{ filter_section | safe }}
                                     </div>
                                 </div>
-                                <button type="button" class="btn btn-primary btn-sm" id="apply-filters-button">
+                                <button type="button" class="btn btn-primary btn-sm w-full justify-center sm:w-auto" id="apply-filters-button">
                                     Apply Filters
                                 </button>
                             </div>
@@ -92,7 +92,7 @@
             </div>
 
             <!--Add button-->
-            <div data-data-view-button="add">    
+            <div class="w-full sm:w-auto" data-data-view-button="add">
                 <c-ui.shortcut_tooltip 
                     position="bottom"
                     action="click"
@@ -114,12 +114,14 @@
             </div>
 
             <!--Bulk actions button-->
-            <div data-data-view-button="bulk-actions">
+            <div class="w-full sm:w-auto" data-data-view-button="bulk-actions">
                 <c-ui.shortcut_tooltip position="bottom" shortcut="mod+3">
                     <c-ui.dropdown.body 
                         trigger_text="Bulk Actions"
                         trigger_icon_class="fa fa-list-check"
                         trigger_button_class="btn-secondary"
+                        trigger_class="w-full justify-center gap-2"
+                        wrapper_class="w-full sm:w-auto"
                         size="sm"
                         >
                         <c-ui.dropdown.item 
@@ -135,7 +137,7 @@
             </div>
 
             <!--Export button-->
-            <div data-data-view-button="export">
+            <div class="w-full sm:w-auto" data-data-view-button="export">
                 <c-ui.shortcut_tooltip 
                     position="bottom"  
                     shortcut="mod+4">
@@ -165,7 +167,7 @@
                         trigger_icon_class="fa fa-sliders"
                         trigger_button_class="btn-secondary"
                         trigger_class="w-full justify-center gap-2"
-                        wrapper_class="w-full"
+                        wrapper_class="w-full sm:w-auto"
                         size="sm"
                         width="w-80"
                         >
@@ -186,7 +188,7 @@
             </div>
             
             <!--Select-->
-            <div data-data-view-button="select-preference">
+            <div class="w-full sm:w-auto" data-data-view-button="select-preference">
                 <c-ui.shortcut_tooltip position="bottom" shortcut="mod+6">
                     <c-features.preferences.select_preference_button
                         type="list"

--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/sectioned_layouts/container.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/sectioned_layouts/container.html
@@ -18,7 +18,7 @@
         data-layout-header-section
     >   
         <!--Right Section-->
-        <div class="flex w-full flex-wrap gap-2 sm:w-auto" data-layout-action-group>
+        <div class="flex w-full flex-wrap gap-2 sm:w-auto [&_.btn]:w-full [&_.btn]:justify-center sm:[&_.btn]:w-auto" data-layout-action-group>
             <c-ui.shortcut_tooltip 
                 shortcut="mod+/" 
                 action="click" 
@@ -35,7 +35,7 @@
         <!--End Right Section-->
 
         <!--Left section-->
-        <div class="flex w-full flex-wrap gap-2 sm:w-auto sm:justify-end" data-layout-action-group>
+        <div class="flex w-full flex-wrap gap-2 sm:w-auto sm:justify-end [&_.btn]:w-full [&_.btn]:justify-center sm:[&_.btn]:w-auto" data-layout-action-group>
             {{ buttons_right }}
             {% if can_edit %}
             <c-ui.shortcut_tooltip 
@@ -48,7 +48,7 @@
                 </button>
             </c-ui.shortcut_tooltip>
 
-            <div class="hidden flex-wrap gap-2" data-layout-open-sidebar data-layout-action-group>
+            <div class="hidden w-full flex-wrap gap-2 sm:w-auto [&_.btn]:w-full [&_.btn]:justify-center sm:[&_.btn]:w-auto" data-layout-open-sidebar data-layout-action-group>
                 <c-ui.shortcut_tooltip 
                     shortcut="mod+m" 
                     action="click" 

--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/ui/dropdown/body.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/ui/dropdown/body.html
@@ -200,6 +200,7 @@ Parameters:
                     {% if direction == 'up' %}origin-bottom-right{% else %}origin-top-right{% endif %} right-0
                 {% endif %}
             {% endif %}
+                max-w-[calc(100vw-1rem)] max-h-[calc(100vh-1rem)] overflow-auto
                 bg-white border border-gray-200 rounded-xl focus:outline-none transition-all duration-200 ease-in-out
             {{ menu_class }}
             shadow-lg

--- a/bloomerp/django_bloomerp/bloomerp/templates/mixins/bloomerp_layout_form_mixin.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/mixins/bloomerp_layout_form_mixin.html
@@ -50,7 +50,7 @@
             :extra_attrs="layout_container_extra_attrs"
         >
             <c-slot name="buttons_left">
-                <div data-toggle-non-required-fields-container>
+                <div class="w-full sm:w-auto" data-toggle-non-required-fields-container>
                     <c-ui.shortcut_tooltip
                         shortcut="mod+."
                         position="bottom">
@@ -79,7 +79,7 @@
                     selected_preference_name="{{ layout_preference_object.name }}"
                 />
 
-                <div class="hidden flex gap-3" id="object-crud-container-buttons">
+                <div class="hidden flex w-full flex-wrap gap-2 sm:w-auto" id="object-crud-container-buttons">
                     <button type="button" class="btn btn-sm btn-secondary" id="object-crud-container-back-button">
                         <i class="fa fa-arrow-left"></i>
                         <c-i18n.blocktrans>
@@ -137,7 +137,7 @@
                     selected_preference_name="{{ layout_preference_object.name }}"
                 />
 
-                <div class="hidden flex gap-3" id="object-crud-container-buttons">
+                <div class="hidden flex w-full flex-wrap gap-2 sm:w-auto" id="object-crud-container-buttons">
                     <button type="button" class="btn btn-sm btn-secondary" id="object-crud-container-back-button">
                         <i class="fa fa-arrow-left"></i>
                         <c-i18n.blocktrans>
@@ -199,7 +199,7 @@
         :extra_attrs="layout_container_extra_attrs"
     >
         <c-slot name="buttons_left">
-            <div data-toggle-non-required-fields-container>
+            <div class="w-full sm:w-auto" data-toggle-non-required-fields-container>
                 <c-ui.shortcut_tooltip
                     shortcut="mod+."
                     position="bottom">

--- a/bloomerp/django_bloomerp/bloomerp/templates/views/generic/detail/base.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/views/generic/detail/base.html
@@ -175,7 +175,7 @@
 					<h2 class="text-2xl font-semibold text-gray-900">{{ object }}</h2>
 				</div>
 				<div class="flex flex-col xl:min-h-0 xl:flex-1">
-					<div class="flex flex-wrap justify-center gap-2">
+					<div class="flex flex-wrap justify-center gap-2 px-4 [&_.btn]:max-w-full [&_.btn]:whitespace-normal [&_.btn]:text-center">
 						<button 
 							class="btn btn-secondary btn-sm"
 							hx-get="{% url 'components_activity_log' %}?content_type_id={{ content_type_id }}&object_id={{ object.id }}"


### PR DESCRIPTION
## To-do

Title: Small screen html adjustments necessary

This is a replacement implementation because the prior scope/approach for PR #45 was not sufficient.

## Summary

- Clamp shared dropdown menus to the phone viewport with max width/height and internal scrolling.
- Make every dataview toolbar action wrapper full width on small screens and natural width from `sm` upward, so Filter/Display no longer differ from Add/Bulk/Export/Preference.
- Update sectioned layout action groups used by create/form/detail layout headers so buttons wrap and center cleanly on narrow screens.
- Allow detail side-panel action buttons to wrap long labels instead of forcing horizontal overflow.

## Verification

- `git diff --check` passed.
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py check` passed from `bloomerp/django_bloomerp` with existing celery beat model warnings and the existing duplicate `CostCenter` generated API registration log.
- `npm run type-check` in `bloomerp/django_bloomerp/bloomerp/static_src` could not start because `tsc` is not installed in this checkout.

Testing note: the ticket says testing is not required; verification focused on template hygiene and Django project checks.