### PR TITLE
Activity log should render HTML content as safe

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/templates/views/generic/detail/activity.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/views/generic/detail/activity.html
@@ -20,9 +20,9 @@
 
                         <article class="min-w-0 pb-2">
                             <div class="flex flex-wrap items-center gap-2">
-                                <h3 class="text-base font-medium leading-7 text-gray-950">
-                                    {{ entry.summary_string }}
-                                </h3>
+                                <div class="text-base font-medium leading-7 text-gray-950">
+                                    {{ entry.summary_string|activity_log_html }}
+                                </div>
                                 {% if entry.source %}
                                     <span class="rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500">{{ entry.source }}</span>
                                 {% endif %}
@@ -60,8 +60,8 @@
                                                 {% for change in entry.payload %}
                                                     <tr>
                                                         <td class="whitespace-nowrap px-3 py-2 font-medium text-gray-800">{{ change.field }}</td>
-                                                        <td class="px-3 py-2 text-gray-600">{{ change.from|default:"-" }}</td>
-                                                        <td class="px-3 py-2 text-gray-900">{{ change.to|default:"-" }}</td>
+                                                        <td class="px-3 py-2 text-gray-600">{{ change.from|default:"-"|activity_log_html }}</td>
+                                                        <td class="px-3 py-2 text-gray-900">{{ change.to|default:"-"|activity_log_html }}</td>
                                                     </tr>
                                                 {% endfor %}
                                             </tbody>
@@ -77,7 +77,7 @@
                                                 {% for field_name, value in entry.payload.items %}
                                                     <tr>
                                                         <td class="w-44 whitespace-nowrap bg-gray-50 px-3 py-2 font-medium text-gray-700">{{ field_name }}</td>
-                                                        <td class="px-3 py-2 text-gray-900">{{ value|default:"-" }}</td>
+                                                        <td class="px-3 py-2 text-gray-900">{{ value|default:"-"|activity_log_html }}</td>
                                                     </tr>
                                                 {% endfor %}
                                             </tbody>

--- a/bloomerp/django_bloomerp/bloomerp/templatetags/bloomerp.py
+++ b/bloomerp/django_bloomerp/bloomerp/templatetags/bloomerp.py
@@ -1,3 +1,4 @@
+import bleach
 from django import template
 from django.db.models.manager import Manager
 from django.db.models import Model
@@ -10,6 +11,7 @@ from django.urls import reverse
 from django.contrib.contenttypes.models import ContentType
 from django.utils.safestring import mark_safe
 from django.utils.html import escape, format_html
+from django.utils.text import Truncator
 from django.middleware.csrf import get_token
 import re
 import uuid
@@ -31,6 +33,45 @@ from bloomerp.services.sectioned_layout_services import (
 from bloomerp.widgets.icon_picker_widget import parse_icon_value as parse_icon_value_service
 
 register = template.Library()
+
+ACTIVITY_LOG_VALUE_MAX_LENGTH = 300
+ACTIVITY_LOG_ALLOWED_TAGS = {
+    "a",
+    "blockquote",
+    "br",
+    "code",
+    "em",
+    "li",
+    "ol",
+    "p",
+    "pre",
+    "strong",
+    "ul",
+}
+ACTIVITY_LOG_ALLOWED_ATTRIBUTES = {
+    "a": ["href", "title"],
+}
+ACTIVITY_LOG_ALLOWED_PROTOCOLS = ["http", "https", "mailto"]
+
+
+@register.filter
+def activity_log_html(value):
+    """Return length-limited editor HTML that is safe to render in an activity log."""
+    if value is None:
+        return ""
+
+    cleaned_html = bleach.clean(
+        str(value),
+        tags=ACTIVITY_LOG_ALLOWED_TAGS,
+        attributes=ACTIVITY_LOG_ALLOWED_ATTRIBUTES,
+        protocols=ACTIVITY_LOG_ALLOWED_PROTOCOLS,
+        strip=True,
+    )
+    truncated_html = Truncator(cleaned_html).chars(
+        ACTIVITY_LOG_VALUE_MAX_LENGTH,
+        html=True,
+    )
+    return mark_safe(truncated_html)
 
 
 @register.filter(name="dump_layout_json")

--- a/bloomerp/django_bloomerp/bloomerp/tests/test_template_tags.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/test_template_tags.py
@@ -1,0 +1,88 @@
+from types import SimpleNamespace
+
+from django.template.loader import render_to_string
+from django.test import SimpleTestCase
+from django.utils import timezone
+
+from bloomerp.templatetags.bloomerp import (
+    ACTIVITY_LOG_VALUE_MAX_LENGTH,
+    activity_log_html,
+)
+
+
+class ActivityLogHtmlFilterTests(SimpleTestCase):
+    def test_activity_log_html_preserves_safe_formatting(self):
+        """
+        Use case: An activity-log value contains HTML produced by the text editor.
+        Expected result: Supported formatting renders as HTML instead of visible markup.
+        """
+        # 1. Sanitize a value containing supported editor formatting.
+        rendered = activity_log_html("<p><strong>Important</strong> update</p>")
+
+        # 2. Verify the safe formatting remains in the rendered value.
+        self.assertEqual(str(rendered), "<p><strong>Important</strong> update</p>")
+
+    def test_activity_log_html_removes_executable_content(self):
+        """
+        Use case: An activity-log value contains scripts and executable HTML attributes.
+        Expected result: The value remains readable without executable browser content.
+        """
+        # 1. Sanitize common script injection vectors.
+        rendered = activity_log_html(
+            '<p onclick="alert(1)">Update</p>'
+            '<script>alert(2)</script>'
+            '<a href="javascript:alert(3)">Open</a>'
+        )
+
+        # 2. Verify executable tags, attributes, and URL schemes are removed.
+        self.assertIn("Update", str(rendered))
+        self.assertNotIn("<script", str(rendered))
+        self.assertNotIn("onclick", str(rendered))
+        self.assertNotIn("javascript:", str(rendered))
+
+    def test_activity_log_html_truncates_visible_text_and_closes_tags(self):
+        """
+        Use case: An activity-log value contains more text than the sidebar should display.
+        Expected result: Visible text is capped and the resulting HTML remains well formed.
+        """
+        # 1. Sanitize a long formatted value.
+        rendered = str(
+            activity_log_html(
+                f"<p><strong>{'a' * (ACTIVITY_LOG_VALUE_MAX_LENGTH + 50)}</strong></p>"
+            )
+        )
+
+        # 2. Verify truncation adds an ellipsis and preserves closing tags.
+        self.assertIn("…", rendered)
+        self.assertTrue(rendered.endswith("</strong></p>"))
+        self.assertLessEqual(
+            rendered.count("a"),
+            ACTIVITY_LOG_VALUE_MAX_LENGTH,
+        )
+
+    def test_activity_log_template_uses_sanitized_html_for_changed_values(self):
+        """
+        Use case: The detail sidebar renders an activity entry containing editor HTML.
+        Expected result: Formatting renders in both the summary and details without scripts.
+        """
+        # 1. Build an activity entry containing safe formatting and script injection vectors.
+        value = '<strong>Visible</strong><script>alert("xss")</script>'
+        entry = SimpleNamespace(
+            action="CHANGE",
+            actor=None,
+            payload=[{"field": "notes", "from": "", "to": value}],
+            source="DETAIL",
+            summary_string=f"System changed the field 'notes' to {value}",
+            timestamp=timezone.now(),
+        )
+
+        # 2. Render the same template used by the activity-log component.
+        rendered = render_to_string(
+            "views/generic/detail/activity.html",
+            {"queryset": [entry]},
+        )
+
+        # 3. Verify formatting renders in both locations while scripts never reach the page.
+        self.assertEqual(rendered.count("<strong>Visible</strong>"), 2)
+        self.assertNotIn("<script", rendered)
+        self.assertNotIn("&lt;strong&gt;", rendered)


### PR DESCRIPTION
Todo: 617f86bd-09e3-4e77-a1f6-0e82580a3e7c — Activity log should render HTML content as safe

Summary:
- render activity-log editor content with a restricted HTML allowlist
- strip scripts, event handlers, styles, and unsafe URL protocols before marking content safe
- cap rendered activity-log values at 300 visible characters while preserving valid closing tags
- apply sanitization to summaries, before/after values, and deleted-object values

Tests:
- PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.test_template_tags — passed (4 tests)
- PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.services.test_activity_log_services bloomerp.tests.test_template_tags — passed (13 tests)
- PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python -m py_compile bloomerp/templatetags/bloomerp.py bloomerp/tests/test_template_tags.py — passed

Notes:
- Existing project model-configuration warnings were emitted by Django checks; no test failures occurred.