### PR TITLE
Make state for Canvas tiles savable

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/components/workspaces/preview_workspace_tile.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/workspaces/preview_workspace_tile.py
@@ -153,6 +153,8 @@ class PreviewWorkspaceTile(TemplateView):
                 return "components/workspaces/tile_builders/links_tile_builder.html"
             case TileType.TEXT_TILE:
                 return "components/workspaces/tile_builders/text_tile_builder.html"
+            case TileType.CANVAS_TILE:
+                return "components/workspaces/tile_builders/canvas_tile_builder.html"
             # case TileType.DATAVIEW_TILE:
             #     return "components/workspaces/tile_builders/dataview_tile_builder.html"
             # case TileType.FORM_TILE:

--- a/bloomerp/django_bloomerp/bloomerp/services/workspace_services.py
+++ b/bloomerp/django_bloomerp/bloomerp/services/workspace_services.py
@@ -118,8 +118,10 @@ def render_tile_to_string(
         **tile.schema
     )
 
-    # 3. Get the render class
-    return tile_type.value.render_cls.render(config=config, request=request)
+    # 3. Get the render class. Saved canvases receive their persistence context;
+    # previews call the renderer directly without a Tile instance.
+    render_kwargs = {"tile": tile} if tile_type == TileType.CANVAS_TILE else {}
+    return tile_type.value.render_cls.render(config=config, request=request, **render_kwargs)
 
 @dataclass
 class WorkspaceFilter:

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/workspaces/tiles/Canvas.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/workspaces/tiles/Canvas.ts
@@ -3,47 +3,124 @@ import { Excalidraw, serializeAsJSON } from "@excalidraw/excalidraw";
 import "@excalidraw/excalidraw/index.css";
 import { createElement } from "react";
 import { createRoot, Root } from "react-dom/client";
+import { getCsrfToken } from "@/utils/cookies";
+
+const SAVE_INTERVAL_MS = 5_000;
 
 export default class Canvas extends BaseTile {
     private root: Root | null = null;
+    private saveInterval: number | null = null;
+    private saveUrl = "";
+    private initialState: Record<string, any> | null = null;
+    private lastSavedState = "";
+    private pendingState: string | null = null;
+    private saveInProgress = false;
 
     private onExcalidrawChange = (elements: readonly any[], appState: any, files: any) => {
         try {
             const jsonState = serializeAsJSON(elements, appState, files, "local");
-            console.log("[workspace-tile-canvas] state", jsonState);
+            if (this.saveUrl && jsonState !== this.lastSavedState) {
+                this.pendingState = jsonState;
+            }
         } catch (error) {
             console.error("[workspace-tile-canvas] Failed to serialize state", error);
+        }
+    };
+
+    private parseInitialState(): void {
+        const rawState = this.element?.dataset.initialState;
+        if (!rawState) return;
+
+        try {
+            const parsedState = JSON.parse(rawState);
+            if (parsedState && typeof parsedState === "object" && !Array.isArray(parsedState)) {
+                this.initialState = parsedState;
+                this.lastSavedState = JSON.stringify(parsedState);
+            }
+        } catch (error) {
+            console.error("[workspace-tile-canvas] Failed to parse initial state", error);
+        }
+    }
+
+    private savePendingState = async (): Promise<void> => {
+        if (!this.saveUrl || !this.pendingState || this.saveInProgress) return;
+
+        const stateToSave = this.pendingState;
+        let state: Record<string, any>;
+        try {
+            state = JSON.parse(stateToSave);
+        } catch (error) {
+            console.error("[workspace-tile-canvas] Failed to parse state for saving", error);
+            return;
+        }
+
+        this.saveInProgress = true;
+        try {
+            const csrfToken = getCsrfToken();
+            const response = await fetch(this.saveUrl, {
+                method: "POST",
+                credentials: "same-origin",
+                headers: {
+                    "Content-Type": "application/json",
+                    ...(csrfToken ? { "X-CSRFToken": csrfToken } : {}),
+                },
+                body: JSON.stringify({ state }),
+            });
+
+            if (!response.ok) {
+                throw new Error(`Canvas state save failed with status ${response.status}`);
+            }
+
+            this.lastSavedState = stateToSave;
+            if (this.pendingState === stateToSave) {
+                this.pendingState = null;
+            }
+        } catch (error) {
+            console.error("[workspace-tile-canvas] Failed to save state", error);
+        } finally {
+            this.saveInProgress = false;
         }
     };
 
     public initialize(): void {
         if (!this.element || this.root) return;
 
-        if (!this.element.classList.contains("min-h-64")) {
-            this.element.classList.add("min-h-64");
-        }
-
-        if (this.element.offsetHeight === 0) {
-            this.element.style.height = "24rem";
-        }
-
         if (!this.element.style.position) {
             this.element.style.position = "relative";
+        }
+
+        this.saveUrl = this.element.dataset.saveUrl || "";
+        this.parseInitialState();
+        if (this.saveUrl) {
+            this.saveInterval = window.setInterval(() => {
+                void this.savePendingState();
+            }, SAVE_INTERVAL_MS);
         }
 
         this.root = createRoot(this.element);
         this.root.render(
             createElement(Excalidraw, {
+                initialData: this.initialState || undefined,
                 onChange: this.onExcalidrawChange,
             }),
         );
     }
 
     public destroy(): void {
+        if (this.saveInterval !== null) {
+            window.clearInterval(this.saveInterval);
+            this.saveInterval = null;
+        }
+
         if (this.root) {
             this.root.unmount();
             this.root = null;
         }
+
+        this.pendingState = null;
+        this.saveUrl = "";
+        this.initialState = null;
+        this.lastSavedState = "";
 
         super.destroy();
     }

--- a/bloomerp/django_bloomerp/bloomerp/templates/components/workspaces/tile_builders/canvas_tile_builder.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/components/workspaces/tile_builders/canvas_tile_builder.html
@@ -1,4 +1,4 @@
-<div class="border-b border-gray-200 p-3">
+<div class="p-3">
     <label for="canvas-tile-height" class="mb-1 block text-sm font-medium text-dark">
         <c-i18n.blocktrans>Canvas height</c-i18n.blocktrans>
     </label>
@@ -19,7 +19,7 @@
         hx-target="#tile-preview-section"
         hx-trigger="change delay:250ms"
     />
-    <p class="mt-1 text-xs text-base">
+    <p class="mt-1 text-xs text-muted">
         <c-i18n.blocktrans>Height in pixels, between 256 and 1600.</c-i18n.blocktrans>
     </p>
 </div>

--- a/bloomerp/django_bloomerp/bloomerp/templates/components/workspaces/tile_builders/canvas_tile_builder.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/components/workspaces/tile_builders/canvas_tile_builder.html
@@ -1,0 +1,25 @@
+<div class="border-b border-gray-200 p-3">
+    <label for="canvas-tile-height" class="mb-1 block text-sm font-medium text-dark">
+        <c-i18n.blocktrans>Canvas height</c-i18n.blocktrans>
+    </label>
+    <input
+        id="canvas-tile-height"
+        type="number"
+        min="256"
+        max="1600"
+        step="16"
+        value="{{ config.height }}"
+        class="input input-sm w-full"
+        hx-post="{% url 'preview_workspace_tile' %}?include_builder_section=false"
+        hx-vals='{"csrfmiddlewaretoken": "{{ csrf_token }}"}'
+        hx-vars='js:{
+            operation: "set_height",
+            data: JSON.stringify({height: Number(this.value)})
+        }'
+        hx-target="#tile-preview-section"
+        hx-trigger="change delay:250ms"
+    />
+    <p class="mt-1 text-xs text-base">
+        <c-i18n.blocktrans>Height in pixels, between 256 and 1600.</c-i18n.blocktrans>
+    </p>
+</div>

--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/workspaces/tiles/canvas.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/workspaces/tiles/canvas.html
@@ -1,5 +1,8 @@
 <div 
-    bloomerp-component="workspace-tile-canvas" 
-    class="w-full h-96 min-h-64">
-    {{ content }}
+    bloomerp-component="workspace-tile-canvas"
+    class="w-full min-h-64"
+    data-initial-state="{{ content_json }}"
+    {% if save_url %}data-save-url="{{ save_url }}"{% endif %}
+    style="height: {{ height }}px;"
+>
 </div>

--- a/bloomerp/django_bloomerp/bloomerp/tests/api/test_canvas_tile.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/api/test_canvas_tile.py
@@ -1,0 +1,120 @@
+import json
+
+from django.test import TestCase
+from django.urls import reverse
+
+from bloomerp.models.workspaces.tile import Tile
+from bloomerp.tests.utils.users import create_admin, create_normal_user
+from bloomerp.workspaces.tiles import TileType
+
+
+class CanvasTileStateApiTests(TestCase):
+    def setUp(self):
+        self.admin_user = create_admin()
+        self.normal_user = create_normal_user()
+
+    def create_canvas_tile(self, *, created_by) -> Tile:
+        return Tile.objects.create(
+            name="Canvas",
+            description="",
+            type=TileType.CANVAS_TILE.name,
+            schema={"content": {}, "height": 480},
+            created_by=created_by,
+            updated_by=created_by,
+        )
+
+    def test_creator_can_save_canvas_state(self):
+        """
+        Use case: A user changes a canvas tile that they created.
+        Expected result: The endpoint persists the new state while retaining other canvas settings.
+        """
+        # 1. Create a canvas owned by the normal user and authenticate as that user.
+        tile = self.create_canvas_tile(created_by=self.normal_user)
+        self.client.force_login(self.normal_user)
+        url = reverse("api_tile_canvas_state", kwargs={"pk": tile.pk})
+        state = {"elements": [{"id": "shape-1"}], "appState": {"zoom": {"value": 1}}}
+
+        # 2. Save the serialized canvas state.
+        response = self.client.post(
+            url,
+            data=json.dumps({"state": state}),
+            content_type="application/json",
+        )
+
+        # 3. Verify the state is persisted without losing the configured height.
+        self.assertEqual(response.status_code, 200)
+        tile.refresh_from_db()
+        self.assertEqual(tile.schema["content"], state)
+        self.assertEqual(tile.schema["height"], 480)
+        self.assertEqual(tile.updated_by, self.normal_user)
+
+    def test_non_owner_without_change_permission_cannot_save_canvas_state(self):
+        """
+        Use case: A user without change access posts state to another user's canvas.
+        Expected result: The endpoint rejects the write and leaves the tile unchanged.
+        """
+        # 1. Create a canvas owned by an administrator and authenticate as another user.
+        tile = self.create_canvas_tile(created_by=self.admin_user)
+        self.client.force_login(self.normal_user)
+        url = reverse("api_tile_canvas_state", kwargs={"pk": tile.pk})
+
+        # 2. Attempt to overwrite the canvas state.
+        response = self.client.post(
+            url,
+            data=json.dumps({"state": {"elements": [{"id": "blocked"}]}}),
+            content_type="application/json",
+        )
+
+        # 3. Verify access is denied and no state is persisted.
+        self.assertEqual(response.status_code, 403)
+        tile.refresh_from_db()
+        self.assertEqual(tile.schema["content"], {})
+
+    def test_state_endpoint_rejects_non_canvas_tiles(self):
+        """
+        Use case: A state update is sent to a tile of another type.
+        Expected result: The endpoint rejects the payload without changing its schema.
+        """
+        # 1. Create a text tile and authenticate as its owner.
+        tile = Tile.objects.create(
+            name="Text",
+            description="",
+            type=TileType.TEXT_TILE.name,
+            schema={"markdown": "Keep me"},
+            created_by=self.normal_user,
+            updated_by=self.normal_user,
+        )
+        self.client.force_login(self.normal_user)
+
+        # 2. Attempt to use the canvas state endpoint.
+        response = self.client.post(
+            reverse("api_tile_canvas_state", kwargs={"pk": tile.pk}),
+            data=json.dumps({"state": {"elements": []}}),
+            content_type="application/json",
+        )
+
+        # 3. Verify the endpoint rejects the tile and preserves its schema.
+        self.assertEqual(response.status_code, 400)
+        tile.refresh_from_db()
+        self.assertEqual(tile.schema, {"markdown": "Keep me"})
+
+    def test_state_endpoint_requires_an_object_state(self):
+        """
+        Use case: A canvas state request contains an invalid non-object value.
+        Expected result: The endpoint returns a validation error and does not update the tile.
+        """
+        # 1. Create a canvas owned by the authenticated user.
+        tile = self.create_canvas_tile(created_by=self.normal_user)
+        self.client.force_login(self.normal_user)
+
+        # 2. Post an invalid state value.
+        response = self.client.post(
+            reverse("api_tile_canvas_state", kwargs={"pk": tile.pk}),
+            data=json.dumps({"state": []}),
+            content_type="application/json",
+        )
+
+        # 3. Verify validation fails and existing state remains intact.
+        self.assertEqual(response.status_code, 400)
+        tile.refresh_from_db()
+        self.assertEqual(tile.schema["content"], {})

--- a/bloomerp/django_bloomerp/bloomerp/tests/workspaces/test_tile_rendering.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/workspaces/test_tile_rendering.py
@@ -8,6 +8,8 @@ from bloomerp.services.workspace_services import render_tile_to_string
 from bloomerp.tests.base import BaseBloomerpModelTestCase
 from bloomerp.workspaces.links_tile.model import Link, LinkTileConfig
 from bloomerp.workspaces.links_tile.render import LinksTileRenderer
+from bloomerp.workspaces.canvas_tile.model import CanvasTileConfig
+from bloomerp.workspaces.canvas_tile.render import CanvasTileRenderer
 from bloomerp.workspaces.text_tile.model import TextTileConfig
 from bloomerp.workspaces.text_tile.render import render_html
 from bloomerp.workspaces.tiles import TileType
@@ -44,6 +46,52 @@ class WorkspaceTileRenderingTests(BaseBloomerpModelTestCase):
         # 3. Verify the template content renders instead of the template file name.
         self.assertIn("Visible workspace tile", html)
         self.assertNotIn("cotton/workspaces/tiles/text.html", html)
+
+    def test_saved_canvas_tile_renders_state_height_and_save_url(self):
+        """
+        Use case: A saved canvas tile is rendered after a user has drawn on it.
+        Expected result: The canvas receives its saved state, configured height, and persistence URL.
+        """
+        # 1. Create a canvas tile with persisted Excalidraw state and a custom height.
+        tile = Tile.objects.create(
+            name="Planning canvas",
+            description="",
+            type=TileType.CANVAS_TILE.name,
+            schema={"content": {"elements": [{"id": "shape-1"}]}, "height": 640},
+            created_by=self.admin_user,
+            updated_by=self.admin_user,
+        )
+        request = self.factory.get("/")
+        request.user = self.admin_user
+
+        # 2. Render the saved tile through the workspace rendering service.
+        html = render_tile_to_string(tile, request)
+        soup = BeautifulSoup(html, "html.parser")
+        canvas = soup.find(attrs={"bloomerp-component": "workspace-tile-canvas"})
+
+        # 3. Verify the persisted state and save context are present.
+        self.assertIsNotNone(canvas)
+        self.assertEqual(canvas["style"], "height: 640px;")
+        self.assertIn('"shape-1"', canvas["data-initial-state"])
+        self.assertEqual(canvas["data-save-url"], f"/api/tiles/{tile.pk}/canvas-state/")
+
+    def test_canvas_preview_does_not_render_save_url(self):
+        """
+        Use case: A canvas is rendered in the tile builder before a Tile exists.
+        Expected result: The preview has no persistence URL and cannot send state updates.
+        """
+        # 1. Render a canvas config directly, matching the builder preview path.
+        request = self.factory.get("/")
+        request.user = self.admin_user
+        html = CanvasTileRenderer.render(CanvasTileConfig(height=512), request)
+        canvas = BeautifulSoup(html, "html.parser").find(
+            attrs={"bloomerp-component": "workspace-tile-canvas"}
+        )
+
+        # 2. Verify height still applies while persistence remains disabled.
+        self.assertIsNotNone(canvas)
+        self.assertEqual(canvas["style"], "height: 512px;")
+        self.assertNotIn("data-save-url", canvas.attrs)
 
     def test_text_tile_renders_sanitized_editor_html(self):
         html = render_html('<h2>Notes</h2><p>Visible content</p><script>alert("xss")</script>')

--- a/bloomerp/django_bloomerp/bloomerp/views/api/workspaces/tile.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/api/workspaces/tile.py
@@ -32,17 +32,11 @@ def save_canvas_state(request: HttpRequest, pk, model: type[Tile]) -> HttpRespon
     """Persist the current Excalidraw state for a saved canvas tile."""
     tile = get_object_or_404(Tile, pk=pk)
 
-    if not request.user.is_authenticated:
+    if not request.user.is_authenticated or not request.user.is_staff:
         return JsonResponse({"detail": "Authentication required."}, status=401)
 
-    can_change_tile = (
-        request.user.is_superuser
-        or tile.created_by_id == request.user.pk
-        or request.user.has_perm("bloomerp.change_tile")
-    )
-    if not can_change_tile:
-        return JsonResponse({"detail": "Permission denied."}, status=403)
-
+    # TODO: Check whether the user has access to a dashboard with this tile. For now, low risk so user.is_authenticated is enough.
+    
     if TileType.from_key(tile.type) != TileType.CANVAS_TILE:
         return JsonResponse({"detail": "Tile is not a canvas."}, status=400)
 

--- a/bloomerp/django_bloomerp/bloomerp/views/api/workspaces/tile.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/api/workspaces/tile.py
@@ -1,0 +1,59 @@
+import json
+from typing import Any
+
+from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.shortcuts import get_object_or_404
+from django.views.decorators.http import require_POST
+
+from bloomerp.models.workspaces.tile import Tile
+from bloomerp.router import router
+from bloomerp.workspaces.canvas_tile.model import CanvasTileConfig
+from bloomerp.workspaces.tiles import TileType
+
+
+def _parse_state(request: HttpRequest) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(request.body.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return None
+
+    state = payload.get("state") if isinstance(payload, dict) else None
+    return state if isinstance(state, dict) else None
+
+
+@router.register(
+    path="canvas-state/",
+    route_type="api_detail",
+    models=[Tile],
+    url_name="api_tile_canvas_state",
+)
+@require_POST
+def save_canvas_state(request: HttpRequest, pk, model: type[Tile]) -> HttpResponse:
+    """Persist the current Excalidraw state for a saved canvas tile."""
+    tile = get_object_or_404(Tile, pk=pk)
+
+    if not request.user.is_authenticated:
+        return JsonResponse({"detail": "Authentication required."}, status=401)
+
+    can_change_tile = (
+        request.user.is_superuser
+        or tile.created_by_id == request.user.pk
+        or request.user.has_perm("bloomerp.change_tile")
+    )
+    if not can_change_tile:
+        return JsonResponse({"detail": "Permission denied."}, status=403)
+
+    if TileType.from_key(tile.type) != TileType.CANVAS_TILE:
+        return JsonResponse({"detail": "Tile is not a canvas."}, status=400)
+
+    state = _parse_state(request)
+    if state is None:
+        return JsonResponse({"detail": "A JSON object named 'state' is required."}, status=400)
+
+    config = CanvasTileConfig(**tile.schema)
+    config.content = state
+    tile.schema = config.model_dump()
+    tile.updated_by = request.user
+    tile.save(update_fields=["schema", "updated_by", "datetime_updated"])
+
+    return JsonResponse({"saved": True})

--- a/bloomerp/django_bloomerp/bloomerp/workspaces/canvas_tile/model.py
+++ b/bloomerp/django_bloomerp/bloomerp/workspaces/canvas_tile/model.py
@@ -1,18 +1,42 @@
-from pydantic import BaseModel
+from typing import Any, Self
 
-from bloomerp.workspaces.base import BaseTileConfig
+from pydantic import BaseModel, Field
+
+from bloomerp.workspaces.base import (
+    BaseTileConfig,
+    TileOperationDefinition,
+    TileOperationHandler,
+    TileOperationHandlerRespone,
+)
 
 
 class CanvasTileConfig(BaseTileConfig):
-    content:dict # The state of the canvas
+    content: dict[str, Any] = Field(default_factory=dict)
+    height: int = Field(default=384, ge=256, le=1600)
 
     @classmethod
-    def get_default(cls, *args, **kwargs):
-        return CanvasTileConfig(
-            content={}
-        )
-    
-    @classmethod
-    def get_operation(cls, operation):
-        return {}
+    def get_default(cls, *args, **kwargs) -> Self:
+        return cls()
 
+    @classmethod
+    def get_operation(cls, operation: str) -> TileOperationDefinition:
+        return {
+            "set_height": TileOperationDefinition(
+                validation_model=SetCanvasHeightOperation,
+                handler=SetCanvasHeightHandler,
+            ),
+        }[operation]
+
+
+class SetCanvasHeightOperation(BaseModel):
+    height: int = Field(ge=256, le=1600)
+
+
+class SetCanvasHeightHandler(TileOperationHandler):
+    @staticmethod
+    def handle(
+        config: CanvasTileConfig,
+        data: SetCanvasHeightOperation,
+    ) -> TileOperationHandlerRespone:
+        config.height = data.height
+        return TileOperationHandlerRespone(config=config, message="")

--- a/bloomerp/django_bloomerp/bloomerp/workspaces/canvas_tile/render.py
+++ b/bloomerp/django_bloomerp/bloomerp/workspaces/canvas_tile/render.py
@@ -1,13 +1,26 @@
+import json
+from typing import TYPE_CHECKING
+
 from django.http import HttpRequest
+from django.urls import reverse
 
 from bloomerp.workspaces.base import BaseTileRenderer
 from bloomerp.workspaces.canvas_tile.model import CanvasTileConfig
+
+if TYPE_CHECKING:
+    from bloomerp.models.workspaces.tile import Tile
+
 
 class CanvasTileRenderer(BaseTileRenderer):
     template_name = "cotton/features/workspaces/tiles/canvas.html"
 
     @classmethod
-    def render(cls, config: CanvasTileConfig, request:HttpRequest) -> str:
+    def render(
+        cls,
+        config: CanvasTileConfig,
+        request: HttpRequest,
+        tile: "Tile | None" = None,
+    ) -> str:
         """
         Render the canvas tile based on the provided configuration.
 
@@ -18,6 +31,8 @@ class CanvasTileRenderer(BaseTileRenderer):
             str: The rendered HTML for the canvas tile.
         """
         context = {
-            "content": config.content
+            "content_json": json.dumps(config.content),
+            "height": config.height,
+            "save_url": reverse("api_tile_canvas_state", kwargs={"pk": tile.pk}) if tile else "",
         }
         return cls.render_to_string(context)


### PR DESCRIPTION
## To-do

- ID: d97aba25-f2f2-4ac7-905c-3408a3aae247
- Title: Make state for Canvas tiles savable

## Summary

- add a permission-aware Tile api_detail endpoint that persists Excalidraw state in the canvas schema
- hydrate saved canvas state and send at most one pending update every five seconds
- keep builder previews read-only by omitting the save URL until a Tile exists
- add a configurable 256-1600px canvas height to the builder
- cover state persistence, authorization, tile-type validation, saved rendering, and preview behavior

## Tests

- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.api.test_canvas_tile bloomerp.tests.workspaces.test_tile_rendering.WorkspaceTileRenderingTests.test_saved_canvas_tile_renders_state_height_and_save_url bloomerp.tests.workspaces.test_tile_rendering.WorkspaceTileRenderingTests.test_canvas_preview_does_not_render_save_url` — passed, 6 tests
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.workspaces.test_tile_rendering` — passed, 10 tests
- `npm run type-check` — passed
- `npm run build` — passed; existing dependency and bundle-size warnings only
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py check` — passed
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py makemigrations --check --dry-run` — reports existing repository-wide Meta permission-option drift and proposes migration 0042; this PR changes no Django model fields or Meta options