### PR TITLE
Add generic content object widget

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/components/global_search.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/global_search.py
@@ -35,17 +35,11 @@ from django.urls import reverse
 from django.urls import NoReverseMatch
 
 
-from bloomerp.models.application_field import ApplicationField
-from bloomerp.models.base_bloomerp_model import BloomerpModel
-from bloomerp.models.definition import BloomerpModelConfig
 from bloomerp.router import router
 from bloomerp.modules.definition import module_registry
 from bloomerp.permissions.manager import UserPermissionManager, create_permission_str
 from bloomerp.services.object_services import string_search_on_queryset
-
-from django.contrib.auth.models import Permission
-from django.contrib.admin.models import LogEntry
-from django.contrib.sessions.models import Session
+from bloomerp.services.search_services import get_accessible_search_models, is_model_searchable
 
 # -------------------------------
 # Helper functions
@@ -118,25 +112,7 @@ def _resolve_models_by_name(model_key: str) -> list:
 
 def _ignore_model(model) -> bool:
     """Determines whether a model should be ignored in the search results."""
-    internal_models = [
-        ContentType,
-        ApplicationField,
-        Permission,
-        LogEntry,
-        Session
-    ]
-
-    if not model or model in internal_models:
-        return True
-    if getattr(model._meta, "swapped", None):
-        return True
-    
-    if hasattr(model, "bloomerp_config") and isinstance(getattr(model, "bloomerp_config"), BloomerpModelConfig):
-        config : BloomerpModelConfig = getattr(model, "bloomerp_config")
-        if config.is_internal or not config.allow_string_search:
-            return True
-
-    return False
+    return not is_model_searchable(model)
 
 def _collect_object_results(
     request: HttpRequest,
@@ -216,23 +192,7 @@ def _get_accessible_models(
     request: HttpRequest,
     permission_manager: UserPermissionManager,
 ) -> list:
-    content_types = list(request.user.accessible_content_types)
-    row_policy_ct_ids = permission_manager.get_row_policies().values_list(
-        "content_type_id", flat=True
-    ).distinct()
-    if row_policy_ct_ids:
-        content_types.extend(ContentType.objects.filter(id__in=row_policy_ct_ids))
-
-    # De-duplicate while preserving order
-    seen_ids = set()
-    unique_content_types = []
-    for ct in content_types:
-        if ct.id in seen_ids:
-            continue
-        seen_ids.add(ct.id)
-        unique_content_types.append(ct)
-
-    return [content_type.model_class() for content_type in unique_content_types]
+    return get_accessible_search_models(request.user, permission_manager)
 
 
 @router.register(path='components/global_search/', name='components_global_search')
@@ -492,7 +452,5 @@ def global_search(request: HttpRequest) -> HttpResponse:
                     TOTAL_LIMIT,
                 )
                 context["results_truncated"] = context["results_truncated"] or truncated
-                
 
     return render(request, "components/global_search.html", context)
-    

--- a/bloomerp/django_bloomerp/bloomerp/components/objects/search_content_objects.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/objects/search_content_objects.py
@@ -1,0 +1,45 @@
+from django.contrib.auth.decorators import login_required
+from django.contrib.contenttypes.models import ContentType
+from django.http import HttpRequest, JsonResponse
+
+from bloomerp.router import router
+from bloomerp.services.object_services import get_object_detail_url, string_search_on_queryset
+from bloomerp.services.permission_services import UserPermissionManager, create_permission_str
+from bloomerp.services.search_services import get_accessible_search_models
+from bloomerp.utils.labels import safe_object_label
+
+
+@router.register(
+    path="components/search-content-objects/",
+    name="components_search_content_objects",
+)
+@login_required
+def search_content_objects(request: HttpRequest) -> JsonResponse:
+    """Search permission-visible objects across accessible content types."""
+    query = (request.GET.get("q") or "").strip()
+    if not query:
+        return JsonResponse({"objects": []})
+
+    permission_manager = UserPermissionManager(request.user)
+    objects = []
+    for model in get_accessible_search_models(request.user, permission_manager):
+        queryset = permission_manager.get_queryset(
+            model,
+            create_permission_str(model, "view"),
+        )
+        matches = string_search_on_queryset(queryset, query)[:5]
+        content_type = ContentType.objects.get_for_model(model)
+        for obj in matches:
+            objects.append(
+                {
+                    "content_type_id": str(content_type.pk),
+                    "object_id": str(obj.pk),
+                    "label": safe_object_label(obj),
+                    "model_label": str(model._meta.verbose_name),
+                    "detail_url": get_object_detail_url(obj),
+                }
+            )
+            if len(objects) >= 20:
+                return JsonResponse({"objects": objects})
+
+    return JsonResponse({"objects": objects})

--- a/bloomerp/django_bloomerp/bloomerp/components/objects/search_objects.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/objects/search_objects.py
@@ -1,23 +1,10 @@
 import json
 from django.http import HttpResponse, HttpRequest
 from django.contrib.contenttypes.models import ContentType
-from django.urls import reverse
 from bloomerp.models import BloomerpModel
 from bloomerp.router import router
-from bloomerp.services.object_services import string_search_on_queryset
+from bloomerp.services.object_services import get_object_detail_url, string_search_on_queryset
 from bloomerp.services.permission_services import UserPermissionManager, create_permission_str
-
-def _get_detail_url(obj) -> str:
-    """Helper function to get the detail url"""
-    try:
-        return obj.get_absolute_url()
-    except Exception:
-        try:
-            from bloomerp.utils.models import get_detail_view_url
-            return reverse(get_detail_view_url(obj.__class__), kwargs={"pk": obj.pk})
-        except Exception:
-            return ""
-
 
 @router.register(
     path="components/search-objects/<int:content_type_id>/",
@@ -62,7 +49,7 @@ def search_objects(request:HttpRequest, content_type_id:int) -> HttpResponse:
             {
                 'id': str(obj.pk),
                 'string_representation': str(obj),
-                'detail_url': _get_detail_url(obj),
+                'detail_url': get_object_detail_url(obj),
             } for obj in results
         ]
     }

--- a/bloomerp/django_bloomerp/bloomerp/field_types/types.py
+++ b/bloomerp/django_bloomerp/bloomerp/field_types/types.py
@@ -19,6 +19,7 @@ from bloomerp.model_fields.week_field import WeekField
 from bloomerp.widgets.address_widget import AddressWidget
 from bloomerp.widgets.code_editor_widget import CodeEditorWidget
 from bloomerp.widgets.foreign_field_widget import ForeignFieldWidget
+from bloomerp.widgets.generic_foreign_key_widget import GenericForeignKeyWidget
 from bloomerp.widgets.icon_picker_widget import IconPickerWidget
 from bloomerp.widgets.object_files_widget import ObjectFilesWidget
 from bloomerp.widgets.one_to_many_field_widget import OneToManyFieldWidget
@@ -176,6 +177,14 @@ class FieldTypeDefinition:
             attrs[self.widget_related_model_attr] = related_model
         if self.widget_parent_model_attr:
             attrs[self.widget_parent_model_attr] = application_field.get_model()
+
+        if self.id == "GenericForeignKey":
+            try:
+                generic_foreign_key = application_field._get_model_field()
+                attrs["content_type_field_name"] = generic_foreign_key.ct_field
+                attrs["object_id_field_name"] = generic_foreign_key.fk_field
+            except Exception:
+                pass
         
         if self.widget_cls:
             return self.get_widget_cls()(
@@ -827,7 +836,9 @@ class FieldType(Enum):
         id="GenericForeignKey",
         display_name="Generic Foreign Key",
         icon="fa-solid fa-link",
+        widget_cls=GenericForeignKeyWidget,
         allow_in_model=False,
+        editable_without_form_field=True,
         dataview_value_func=render_foreign_key_dataview_value
     )
 

--- a/bloomerp/django_bloomerp/bloomerp/models/project_management/todo.py
+++ b/bloomerp/django_bloomerp/bloomerp/models/project_management/todo.py
@@ -74,6 +74,7 @@ class Todo(BloomerpModel):
                         LayoutItem(id="effort", colspan=1),
                         LayoutItem(id="labels", colspan=1),
                         LayoutItem(id="initiative", colspan=1),
+                        LayoutItem(id="content_object", colspan=2),
                         LayoutItem(id="content", colspan=4),
                     ],
                 ),

--- a/bloomerp/django_bloomerp/bloomerp/services/create_view_services.py
+++ b/bloomerp/django_bloomerp/bloomerp/services/create_view_services.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
+from django.contrib.contenttypes.fields import GenericForeignKey
 
 from bloomerp.models import ApplicationField, UserCreateViewPreference
 from bloomerp.models.base_bloomerp_model import FieldLayout
@@ -20,6 +21,32 @@ AUTO_MANAGED_FIELD_NAMES = {
     "comments",
     "files",
 }
+
+
+def get_generic_foreign_key_backing_field_names(model) -> set[str]:
+    """Return concrete field names represented by generic foreign keys."""
+    return {
+        field_name
+        for field in model._meta.private_fields
+        if isinstance(field, GenericForeignKey)
+        for field_name in (field.ct_field, field.fk_field)
+    }
+
+
+def get_generic_foreign_key_backing_fields(application_field: ApplicationField) -> list[ApplicationField]:
+    """Return the concrete ApplicationFields submitted by a generic relation widget."""
+    try:
+        generic_foreign_key = application_field._get_model_field()
+    except Exception:
+        return []
+    if not isinstance(generic_foreign_key, GenericForeignKey):
+        return []
+    return list(
+        ApplicationField.objects.filter(
+            content_type=application_field.content_type,
+            field__in=[generic_foreign_key.ct_field, generic_foreign_key.fk_field],
+        )
+    )
 
 
 @dataclass
@@ -77,9 +104,12 @@ def get_addable_fields(*, content_type: ContentType, user) -> models.QuerySet[Ap
 
     permission_manager = UserPermissionManager(user)
     permission_str = create_permission_str(model, "add")
+    generic_backing_field_names = get_generic_foreign_key_backing_field_names(model)
     accessible_fields = permission_manager.get_accessible_fields(content_type, permission_str).order_by("field")
     allowed_ids: list[int] = []
     for application_field in accessible_fields:
+        if application_field.field in generic_backing_field_names:
+            continue
         if application_field.field in AUTO_MANAGED_FIELD_NAMES:
             continue
         try:
@@ -112,8 +142,11 @@ def get_required_create_fields(*, content_type: ContentType) -> list[Application
         return []
 
     required_fields: list[ApplicationField] = []
+    generic_backing_field_names = get_generic_foreign_key_backing_field_names(model)
     for model_field in model._meta.concrete_fields:
         if model_field.name in AUTO_MANAGED_FIELD_NAMES:
+            continue
+        if model_field.name in generic_backing_field_names:
             continue
         if getattr(model_field, "auto_created", False):
             continue

--- a/bloomerp/django_bloomerp/bloomerp/services/object_services.py
+++ b/bloomerp/django_bloomerp/bloomerp/services/object_services.py
@@ -1,12 +1,32 @@
 """
 All rights reserved. 
 """
+from typing import TYPE_CHECKING
+
 from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.db.models import CharField, F, TextField, Value
 from django.db.models.functions import Concat
+from django.urls import reverse
 
-from bloomerp.models import User
+if TYPE_CHECKING:
+    from bloomerp.models import User
+
+
+def get_object_detail_url(obj) -> str:
+    """Return the object's configured detail URL when one is available."""
+    if hasattr(obj, "get_absolute_url"):
+        try:
+            return obj.get_absolute_url()
+        except Exception:
+            pass
+
+    try:
+        from bloomerp.utils.models import get_detail_view_url
+
+        return reverse(get_detail_view_url(obj.__class__), kwargs={"pk": obj.pk})
+    except Exception:
+        return ""
 
 def string_search_on_queryset(queryset: QuerySet, query: str):
     """
@@ -96,7 +116,7 @@ def string_search_on_queryset(queryset: QuerySet, query: str):
 
 
 class UserCrudManager:
-    def __init__(self, user:User):
+    def __init__(self, user: "User"):
         self.user = user
 
     def create_form(self, model_or_content_type):

--- a/bloomerp/django_bloomerp/bloomerp/services/search_services.py
+++ b/bloomerp/django_bloomerp/bloomerp/services/search_services.py
@@ -1,0 +1,42 @@
+from django.contrib.admin.models import LogEntry
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.sessions.models import Session
+
+from bloomerp.models.application_field import ApplicationField
+from bloomerp.models.definition import BloomerpModelConfig
+from bloomerp.services.permission_services import UserPermissionManager
+
+
+def is_model_searchable(model) -> bool:
+    """Return whether a model may appear in cross-model object search."""
+    internal_models = [ContentType, ApplicationField, Permission, LogEntry, Session]
+    if not model or model in internal_models or getattr(model._meta, "swapped", None):
+        return False
+
+    config = getattr(model, "bloomerp_config", None)
+    if isinstance(config, BloomerpModelConfig):
+        return not config.is_internal and config.allow_string_search
+    return True
+
+
+def get_accessible_search_models(user, permission_manager: UserPermissionManager | None = None) -> list:
+    """Return de-duplicated models visible through auth or row policies."""
+    permission_manager = permission_manager or UserPermissionManager(user)
+    content_types = list(user.accessible_content_types)
+    row_policy_ct_ids = permission_manager.get_row_policies().values_list(
+        "content_type_id", flat=True
+    ).distinct()
+    if row_policy_ct_ids:
+        content_types.extend(ContentType.objects.filter(id__in=row_policy_ct_ids))
+
+    seen_ids: set[int] = set()
+    models = []
+    for content_type in content_types:
+        if content_type.id in seen_ids:
+            continue
+        seen_ids.add(content_type.id)
+        model = content_type.model_class()
+        if is_model_searchable(model):
+            models.append(model)
+    return models

--- a/bloomerp/django_bloomerp/bloomerp/services/sectioned_layout_services.py
+++ b/bloomerp/django_bloomerp/bloomerp/services/sectioned_layout_services.py
@@ -308,8 +308,12 @@ def get_available_layout_fields(*, content_type: ContentType, user, layout_kind:
         AUTO_MANAGED_FIELD_NAMES = frozenset()
 
     fields = ApplicationField.objects.filter(content_type=content_type).order_by("field")
+    from bloomerp.services.create_view_services import get_generic_foreign_key_backing_field_names
+    generic_backing_field_names = get_generic_foreign_key_backing_field_names(model)
     available: list[dict[str, Any]] = []
     for field in fields:
+        if field.field in generic_backing_field_names:
+            continue
         if not permission_manager.has_field_permission(field, permission_str):
             continue
 

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/GenericForeignKeyWidget.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/GenericForeignKeyWidget.ts
@@ -1,0 +1,237 @@
+import { attachObjectPreviewTooltip, hideObjectPreviewTooltip } from "@/utils/objectPreviewTooltip";
+import { BaseWidget, type BaseWidgetSerializableState } from "./BaseWidget";
+
+type GenericForeignKeyValue = {
+    contentTypeId: string;
+    objectId: string;
+    label: string;
+    url: string;
+};
+
+type GenericForeignKeySerializableState = BaseWidgetSerializableState & GenericForeignKeyValue & {
+    inputValue: string;
+};
+
+export default class GenericForeignKeyWidget extends BaseWidget {
+    private input: HTMLInputElement | null = null;
+    private dropdown: HTMLElement | null = null;
+    private resultsList: HTMLUListElement | null = null;
+    private selectedContainer: HTMLElement | null = null;
+    private contentTypeInput: HTMLInputElement | null = null;
+    private objectIdInput: HTMLInputElement | null = null;
+    private debounceTimer: number | null = null;
+    private outsideClickHandler: ((event: MouseEvent) => void) | null = null;
+    private inputHandler: (() => void) | null = null;
+    private resultClickHandler: ((event: Event) => void) | null = null;
+    private previewCleanup: (() => void) | null = null;
+    private isDisabled = false;
+
+    public initialize(): void {
+        if (!this.element) return;
+
+        const contentTypeFieldName = this.element.dataset.contentTypeFieldName || "";
+        const objectIdFieldName = this.element.dataset.objectIdFieldName || "";
+        this.input = this.element.querySelector('input[type="text"]');
+        this.dropdown = this.element.querySelector(".generic-foreign-key-dropdown");
+        this.resultsList = this.element.querySelector(".generic-foreign-key-results");
+        this.selectedContainer = this.element.querySelector(".generic-foreign-key-selected");
+        this.contentTypeInput = this.element.querySelector(`input[type="hidden"][name="${contentTypeFieldName}"]`);
+        this.objectIdInput = this.element.querySelector(`input[type="hidden"][name="${objectIdFieldName}"]`);
+        this.isDisabled = this.element.dataset.disabled === "true";
+
+        if (!this.input || !this.dropdown || !this.resultsList || !this.selectedContainer || !this.contentTypeInput || !this.objectIdInput) {
+            return;
+        }
+
+        this.renderSelectedState();
+        if (this.isDisabled) return;
+
+        this.inputHandler = () => this.onInput();
+        this.resultClickHandler = (event: Event) => this.onResultClick(event);
+        this.outsideClickHandler = (event: MouseEvent) => {
+            if (!this.element.contains(event.target as Node)) this.hideDropdown();
+        };
+        this.input.addEventListener("input", this.inputHandler);
+        this.resultsList.addEventListener("click", this.resultClickHandler);
+        document.addEventListener("click", this.outsideClickHandler);
+    }
+
+    public destroy(): void {
+        if (this.input && this.inputHandler) this.input.removeEventListener("input", this.inputHandler);
+        if (this.resultsList && this.resultClickHandler) this.resultsList.removeEventListener("click", this.resultClickHandler);
+        if (this.outsideClickHandler) document.removeEventListener("click", this.outsideClickHandler);
+        if (this.debounceTimer) window.clearTimeout(this.debounceTimer);
+        this.cleanupPreview();
+    }
+
+    private onInput(): void {
+        if (!this.input) return;
+        const query = this.input.value.trim();
+        if (this.debounceTimer) window.clearTimeout(this.debounceTimer);
+        if (
+            this.objectIdInput?.value
+            && query !== (this.element.dataset.selectedLabel || "").trim()
+        ) {
+            this.clearSelection(false);
+            this.input.value = query;
+        }
+        if (!query) {
+            this.clearSelection(false);
+            this.hideDropdown();
+            return;
+        }
+
+        this.debounceTimer = window.setTimeout(() => this.fetchResults(query), 250);
+    }
+
+    private async fetchResults(query: string): Promise<void> {
+        const searchUrl = this.element.dataset.searchUrl;
+        if (!searchUrl) return;
+
+        try {
+            const separator = searchUrl.includes("?") ? "&" : "?";
+            const response = await fetch(`${searchUrl}${separator}q=${encodeURIComponent(query)}`, { credentials: "same-origin" });
+            if (!response.ok) return;
+            const data = await response.json();
+            this.renderResults(data.objects || []);
+        } catch (error) {
+            console.error("GenericForeignKeyWidget search error", error);
+        }
+    }
+
+    private renderResults(objects: Array<{ content_type_id: string; object_id: string; label: string; model_label: string; detail_url?: string }>): void {
+        if (!this.resultsList || !this.dropdown) return;
+        this.resultsList.innerHTML = "";
+
+        if (!objects.length) {
+            const empty = document.createElement("li");
+            empty.className = "px-3 py-2 text-gray-500";
+            empty.textContent = "No results";
+            this.resultsList.appendChild(empty);
+        } else {
+            objects.forEach((object) => {
+                const item = document.createElement("li");
+                item.className = "cursor-pointer px-3 py-2 hover:bg-gray-50";
+                item.dataset.contentTypeId = String(object.content_type_id);
+                item.dataset.objectId = String(object.object_id);
+                item.dataset.label = object.label;
+                item.dataset.url = object.detail_url || "";
+
+                const label = document.createElement("div");
+                label.className = "truncate text-gray-900";
+                label.textContent = object.label;
+                const modelLabel = document.createElement("div");
+                modelLabel.className = "text-xs text-gray-500";
+                modelLabel.textContent = object.model_label;
+                item.append(label, modelLabel);
+                this.resultsList?.appendChild(item);
+            });
+        }
+        this.dropdown.classList.remove("hidden");
+    }
+
+    private onResultClick(event: Event): void {
+        const item = (event.target as HTMLElement).closest("li[data-content-type-id]") as HTMLElement | null;
+        if (!item) return;
+        this.setSelection({
+            contentTypeId: item.dataset.contentTypeId || "",
+            objectId: item.dataset.objectId || "",
+            label: item.dataset.label || item.dataset.objectId || "",
+            url: item.dataset.url || "",
+        });
+    }
+
+    private setSelection(value: GenericForeignKeyValue, emitChange = true): void {
+        const previousValue = this.getValue();
+        if (!this.contentTypeInput || !this.objectIdInput || !this.input) return;
+        this.contentTypeInput.value = value.contentTypeId;
+        this.objectIdInput.value = value.objectId;
+        this.element.dataset.selectedLabel = value.label;
+        this.element.dataset.selectedUrl = value.url;
+        this.input.value = value.label;
+        this.renderSelectedState();
+        this.hideDropdown();
+        if (emitChange && JSON.stringify(previousValue) !== JSON.stringify(this.getValue())) this.onChange();
+    }
+
+    private clearSelection(emitChange = true): void {
+        this.setSelection({ contentTypeId: "", objectId: "", label: "", url: "" }, emitChange);
+    }
+
+    private renderSelectedState(): void {
+        if (!this.selectedContainer || !this.contentTypeInput || !this.objectIdInput) return;
+        this.cleanupPreview();
+        this.selectedContainer.innerHTML = "";
+        if (!this.contentTypeInput.value || !this.objectIdInput.value) return;
+
+        const badge = document.createElement("span");
+        badge.className = "inline-flex items-center gap-1 rounded-full bg-primary px-2 py-1 text-xs text-white";
+        const label = this.element.dataset.selectedLabel || this.objectIdInput.value;
+        const url = this.element.dataset.selectedUrl || "";
+        const content = document.createElement(url ? "a" : "span");
+        content.className = "max-w-56 truncate px-1";
+        content.textContent = label;
+        if (url) content.setAttribute("href", url);
+        badge.appendChild(content);
+
+        if (!this.isDisabled) {
+            const remove = document.createElement("button");
+            remove.type = "button";
+            remove.className = "rounded-full px-1 leading-none hover:bg-white/20";
+            remove.setAttribute("aria-label", `Remove ${label}`);
+            remove.textContent = "×";
+            remove.addEventListener("click", (event) => {
+                event.preventDefault();
+                this.clearSelection();
+            });
+            badge.appendChild(remove);
+        }
+
+        this.selectedContainer.appendChild(badge);
+        this.previewCleanup = attachObjectPreviewTooltip({
+            element: content,
+            objectId: this.objectIdInput.value,
+            contentTypeId: this.contentTypeInput.value,
+        });
+    }
+
+    private cleanupPreview(): void {
+        this.previewCleanup?.();
+        this.previewCleanup = null;
+        hideObjectPreviewTooltip();
+    }
+
+    private hideDropdown(): void {
+        this.dropdown?.classList.add("hidden");
+    }
+
+    public getValue(): GenericForeignKeyValue {
+        return {
+            contentTypeId: this.contentTypeInput?.value || "",
+            objectId: this.objectIdInput?.value || "",
+            label: this.element.dataset.selectedLabel || "",
+            url: this.element.dataset.selectedUrl || "",
+        };
+    }
+
+    public setValue(value: unknown, emitChange = false): void {
+        if (!value || typeof value !== "object") return;
+        const nextValue = value as Partial<GenericForeignKeyValue>;
+        this.setSelection({
+            contentTypeId: String(nextValue.contentTypeId || ""),
+            objectId: String(nextValue.objectId || ""),
+            label: String(nextValue.label || nextValue.objectId || ""),
+            url: String(nextValue.url || ""),
+        }, emitChange);
+    }
+
+    public override getSerializableState(): GenericForeignKeySerializableState {
+        return { ...this.getValue(), value: this.getValue(), inputValue: this.input?.value || "" };
+    }
+
+    public override setSerializableState(state: BaseWidgetSerializableState, emitChange = false): void {
+        const nextState = state as GenericForeignKeySerializableState;
+        this.setValue(nextState, emitChange);
+        if (this.input) this.input.value = nextState.inputValue || nextState.label || "";
+    }
+}

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/main.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/main.ts
@@ -26,6 +26,7 @@ import PermissionCheckboxes from './components/inputs/PermissionCheckboxes';
 import DropdownInput from './components/inputs/DropdownInput';
 import SelectableCards from './components/inputs/SelectableCards';
 import ForeignFieldWidget from './components/widgets/ForeignFieldWidget';
+import GenericForeignKeyWidget from './components/widgets/GenericForeignKeyWidget';
 import ListFilterWidget from './components/widgets/ListFilterWidget';
 import OneToManyFieldWidget from './components/widgets/OneToManyFieldWidget';
 import CodeEditorWidget from './components/widgets/CodeEditorWidget';
@@ -114,6 +115,7 @@ registerComponent('selectable-cards', SelectableCards);
 
 // Form widgets
 registerComponent('foreign-field-widget', ForeignFieldWidget);
+registerComponent('generic-foreign-key-widget', GenericForeignKeyWidget);
 registerComponent('list-filter-widget', ListFilterWidget);
 registerComponent('one-to-many-field-widget', OneToManyFieldWidget);
 registerComponent('code-editor-widget', CodeEditorWidget);

--- a/bloomerp/django_bloomerp/bloomerp/templates/widgets/generic_foreign_key_widget.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/widgets/generic_foreign_key_widget.html
@@ -1,0 +1,31 @@
+<div
+    bloomerp-component="generic-foreign-key-widget"
+    data-search-url="{{ search_url }}"
+    data-content-type-field-name="{{ content_type_field_name }}"
+    data-object-id-field-name="{{ object_id_field_name }}"
+    data-content-type-id="{{ selected_content_type_id }}"
+    data-object-id="{{ selected_object_id }}"
+    data-selected-label="{{ selected_label }}"
+    data-selected-url="{{ selected_url }}"
+    data-disabled="{{ widget.attrs.disabled|yesno:'true,false' }}"
+    class="relative"
+    id="id_{{ widget.name }}"
+>
+    <div class="relative">
+        <input
+            type="text"
+            class="{{ widget.attrs.class }}"
+            value="{{ selected_label }}"
+            autocomplete="off"
+            {% if widget.attrs.disabled %}disabled{% endif %}
+        >
+        <div class="generic-foreign-key-dropdown hidden absolute left-0 right-0 top-full z-50 mt-1">
+            <ul class="generic-foreign-key-results max-h-64 list-none overflow-auto rounded-xl border border-gray-200 bg-white p-0 text-sm shadow-xs"></ul>
+        </div>
+    </div>
+
+    <input type="hidden" name="{{ content_type_field_name }}" value="{{ selected_content_type_id }}" {% if widget.attrs.disabled %}disabled{% endif %}>
+    <input type="hidden" name="{{ object_id_field_name }}" value="{{ selected_object_id }}" {% if widget.attrs.disabled %}disabled{% endif %}>
+
+    <div class="generic-foreign-key-selected mt-2" aria-live="polite"></div>
+</div>

--- a/bloomerp/django_bloomerp/bloomerp/tests/components/test_search_content_objects.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/components/test_search_content_objects.py
@@ -1,0 +1,70 @@
+import json
+
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from bloomerp.tests.base import BaseBloomerpModelTestCase
+
+
+class SearchContentObjectsTests(BaseBloomerpModelTestCase):
+    auto_create_customers = False
+
+    def test_search_returns_matching_object_with_generic_relation_keys(self):
+        """
+        Use case: A permitted user searches the generic content-object widget.
+        Expected result: Matching objects include both content type and object identifiers.
+        """
+        # 1. Create matching and non-matching records and authenticate as a superuser.
+        matching = self.create_customer(first_name="Generic", last_name="Target", age=30)
+        self.create_customer(first_name="Different", last_name="Customer", age=31)
+        self.client.force_login(self.admin_user)
+
+        # 2. Search across accessible models.
+        response = self.client.get(
+            reverse("components_search_content_objects"),
+            {"q": "Generic Target"},
+        )
+
+        # 3. Verify only the match is returned with its generic relation keys.
+        self.assertEqual(response.status_code, 200)
+        objects = json.loads(response.content)["objects"]
+        self.assertEqual(len(objects), 1)
+        self.assertEqual(objects[0]["object_id"], str(matching.pk))
+        self.assertEqual(
+            objects[0]["content_type_id"],
+            str(ContentType.objects.get_for_model(self.CustomerModel).pk),
+        )
+        self.assertEqual(objects[0]["label"], "Generic Target")
+
+    def test_search_excludes_objects_without_view_access(self):
+        """
+        Use case: A user without view permission searches for an existing object.
+        Expected result: The permission-bounded endpoint returns no objects.
+        """
+        # 1. Create a searchable record and authenticate a user without a policy.
+        self.create_customer(first_name="Private", last_name="Target", age=30)
+        self.client.force_login(self.normal_user)
+
+        # 2. Search for the record.
+        response = self.client.get(
+            reverse("components_search_content_objects"),
+            {"q": "Private Target"},
+        )
+
+        # 3. Verify the inaccessible object is absent.
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content)["objects"], [])
+
+    def test_search_requires_authentication(self):
+        """
+        Use case: An anonymous request calls the content-object search endpoint.
+        Expected result: The request is redirected to authentication.
+        """
+        # 1. Call the endpoint without logging in.
+        response = self.client.get(
+            reverse("components_search_content_objects"),
+            {"q": "anything"},
+        )
+
+        # 2. Verify authentication is required.
+        self.assertEqual(response.status_code, 302)

--- a/bloomerp/django_bloomerp/bloomerp/tests/models/test_application_field.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/models/test_application_field.py
@@ -17,6 +17,7 @@ from bloomerp.models.forms.form import Form as BloomerpForm
 from bloomerp.models.forms.form_submission import FormSubmission
 from bloomerp.services.sectioned_layout_services import build_crud_layout_field_context
 from bloomerp.services.form_services import FormManager
+from bloomerp.services.create_view_services import get_addable_fields
 from bloomerp.services.one_to_many_field_services import (
     save_submitted_one_to_many_fields,
 )
@@ -31,6 +32,7 @@ from bloomerp.tests.base import BaseBloomerpModelTestCase
 from bloomerp.tests.utils.dynamic_models import create_test_models
 from bloomerp.widgets.address_widget import AddressWidget
 from bloomerp.widgets.code_editor_widget import CodeEditorWidget
+from bloomerp.widgets.generic_foreign_key_widget import GenericForeignKeyWidget
 from bloomerp.widgets.object_files_widget import ObjectFilesWidget
 from bloomerp.widgets.one_to_many_field_widget import OneToManyFieldWidget
 from bloomerp.widgets.phone_number_widget import PhoneNumberWidget
@@ -157,6 +159,81 @@ class TestApplicationField(BaseBloomerpModelTestCase):
         self.assertIs(field_type.widget_cls, OneToManyFieldWidget)
         self.assertEqual(field_type.widget_related_model_attr, "related_model")
         self.assertTrue(field_type.editable_without_form_field)
+
+    def test_generic_foreign_key_field_type_owns_widget_behavior(self):
+        """
+        Use case: A model exposes a GenericForeignKey through ApplicationField metadata.
+        Expected result: The field type supplies the cross-model widget as a layout-only editable field.
+        """
+        # 1. Resolve the Todo content-object field created by application-field synchronization.
+        from bloomerp.models.project_management.todo import Todo
+
+        application_field = ApplicationField.objects.get(
+            content_type=ContentType.objects.get_for_model(Todo),
+            field="content_object",
+        )
+
+        # 2. Build its widget and verify the descriptor's backing field names are retained.
+        widget = application_field.get_widget()
+
+        self.assertIsInstance(widget, GenericForeignKeyWidget)
+        self.assertEqual(widget.content_type_field_name, "content_type")
+        self.assertEqual(widget.object_id_field_name, "object_id")
+        self.assertTrue(application_field.get_field_type_enum().value.editable_without_form_field)
+
+    def test_generic_foreign_key_widget_renders_selected_object(self):
+        """
+        Use case: An existing generic relation is rendered in an overview form.
+        Expected result: One visible selector submits both generic relation keys.
+        """
+        # 1. Build the Todo content-object widget and a selected customer.
+        from bloomerp.models.project_management.todo import Todo
+
+        application_field = ApplicationField.objects.get(
+            content_type=ContentType.objects.get_for_model(Todo),
+            field="content_object",
+        )
+        customer = self.CustomerModel.objects.create(
+            first_name="Selected",
+            last_name="Customer",
+            age=30,
+        )
+
+        # 2. Render the widget with that object selected.
+        html = application_field.get_widget().render(
+            name="content_object",
+            value=customer,
+            attrs={"class": "input w-full"},
+        )
+
+        # 3. Verify the selector and its two hidden backing values.
+        customer_content_type = ContentType.objects.get_for_model(self.CustomerModel)
+        self.assertIn('bloomerp-component="generic-foreign-key-widget"', html)
+        self.assertIn('name="content_type"', html)
+        self.assertIn(f'value="{customer_content_type.pk}"', html)
+        self.assertIn('name="object_id"', html)
+        self.assertIn(f'value="{customer.pk}"', html)
+        self.assertIn("Selected Customer", html)
+
+    def test_create_fields_replace_generic_relation_backing_fields(self):
+        """
+        Use case: A create layout is generated for a model with a GenericForeignKey.
+        Expected result: The logical field is offered instead of separate backing fields.
+        """
+        # 1. Resolve the Todo fields available to a superuser create layout.
+        from bloomerp.models.project_management.todo import Todo
+
+        content_type = ContentType.objects.get_for_model(Todo)
+        field_names = set(
+            get_addable_fields(content_type=content_type, user=self.admin_user).values_list(
+                "field", flat=True
+            )
+        )
+
+        # 2. Verify the layout exposes only the logical content-object field.
+        self.assertIn("content_object", field_names)
+        self.assertNotIn("content_type", field_names)
+        self.assertNotIn("object_id", field_names)
 
     def test_files_application_field_uses_files_relation_field_type(self):
         application_field = ApplicationField.objects.get(

--- a/bloomerp/django_bloomerp/bloomerp/tests/views/test_generic_foreign_key_widget.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/views/test_generic_foreign_key_widget.py
@@ -1,0 +1,69 @@
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from bloomerp.models.project_management.todo import Todo
+from bloomerp.tests.base import BaseBloomerpModelTestCase
+
+
+class GenericForeignKeyCrudTests(BaseBloomerpModelTestCase):
+    auto_create_customers = False
+
+    def test_create_view_saves_content_object_widget_values(self):
+        """
+        Use case: A user selects an object in the Todo create view's single content-object widget.
+        Expected result: The created Todo stores the selected content type and object id.
+        """
+        # 1. Create a target object and authenticate as a superuser.
+        customer = self.create_customer(first_name="Create", last_name="Target", age=30)
+        customer_content_type = ContentType.objects.get_for_model(self.CustomerModel)
+        self.client.force_login(self.admin_user)
+
+        # 2. Submit the two hidden values produced by the content-object widget.
+        response = self.client.post(
+            reverse("todos_add"),
+            {
+                "title": "Linked todo",
+                "priority": "medium",
+                "effort": "4",
+                "status": "backlog",
+                "content_type": str(customer_content_type.pk),
+                "object_id": str(customer.pk),
+            },
+        )
+
+        # 3. Verify the generic relation resolves to the selected object.
+        self.assertEqual(response.status_code, 302)
+        todo = Todo.objects.get(title="Linked todo")
+        self.assertEqual(todo.content_type, customer_content_type)
+        self.assertEqual(todo.object_id, str(customer.pk))
+        self.assertEqual(todo.content_object, customer)
+
+    def test_overview_updates_content_object_widget_values(self):
+        """
+        Use case: A user changes the selected content object on a Todo overview.
+        Expected result: Both generic relation backing fields are updated together.
+        """
+        # 1. Create a Todo and two possible target objects.
+        original = self.create_customer(first_name="Original", last_name="Target", age=30)
+        replacement = self.create_customer(first_name="Replacement", last_name="Target", age=31)
+        todo = Todo.objects.create(title="Update linked todo", content_object=original)
+        replacement_content_type = ContentType.objects.get_for_model(self.CustomerModel)
+        self.client.force_login(self.admin_user)
+
+        # 2. Submit the replacement values from the overview widget.
+        response = self.client.post(
+            reverse("todos_detail_overview", kwargs={"pk": todo.pk}),
+            {
+                "title": todo.title,
+                "priority": todo.priority,
+                "effort": str(todo.effort),
+                "status": todo.status,
+                "content_type": str(replacement_content_type.pk),
+                "object_id": str(replacement.pk),
+            },
+        )
+
+        # 3. Verify the Todo now resolves to the replacement object.
+        self.assertEqual(response.status_code, 302)
+        todo.refresh_from_db()
+        self.assertEqual(todo.content_object, replacement)

--- a/bloomerp/django_bloomerp/bloomerp/views/generic/detail/overview.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/generic/detail/overview.py
@@ -13,7 +13,11 @@ from bloomerp.services.object_file_field_services import save_layout_uploaded_fi
 from bloomerp.services.one_to_many_field_services import save_submitted_one_to_many_fields
 from bloomerp.models.users.user_detail_view_preference import UserDetailViewPreference
 from bloomerp.router import router
-from bloomerp.services.create_view_services import AUTO_MANAGED_FIELD_NAMES, get_disallowed_submitted_fields
+from bloomerp.services.create_view_services import (
+    AUTO_MANAGED_FIELD_NAMES,
+    get_disallowed_submitted_fields,
+    get_generic_foreign_key_backing_fields,
+)
 from bloomerp.services.detail_view_services import get_default_layout
 from bloomerp.services.permission_services import UserPermissionManager, create_permission_str
 from bloomerp.utils.models import get_detail_view_url
@@ -78,6 +82,12 @@ class BloomerpDetailOverviewView(BloomerpLayoutFormMixin, BaseBloomerpDetailView
             if application_field.field in AUTO_MANAGED_FIELD_NAMES:
                 continue
             field_type = application_field.get_field_type_enum().value
+            if field_type.id == "GenericForeignKey":
+                allowed_field_names.extend(
+                    backing_field.field
+                    for backing_field in get_generic_foreign_key_backing_fields(application_field)
+                )
+                continue
             if not field_type.allow_in_model:
                 continue
             try:

--- a/bloomerp/django_bloomerp/bloomerp/views/generic/model/create.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/generic/model/create.py
@@ -10,13 +10,14 @@ from django.shortcuts import redirect
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.generic.edit import CreateView
 
-from bloomerp.models import UserCreateViewPreference
+from bloomerp.models import ApplicationField, UserCreateViewPreference
 from bloomerp.models.definition import BloomerpModelConfig
 from bloomerp.models.files import File
 from bloomerp.models.workspaces import SqlQuery, Tile
 from bloomerp.models.workspaces.workspace import Workspace
 from bloomerp.router import router
 from bloomerp.services.create_view_services import (
+    get_generic_foreign_key_backing_fields,
     get_create_access_state,
     get_disallowed_submitted_fields,
 )
@@ -92,11 +93,23 @@ class BloomerpCreateView(
         return self.create_view_preference
 
     def get_layout_editable_field_names(self) -> list[str]:
-        return list(self.create_access_state.addable_fields.values_list("field", flat=True))
+        fields = list(self.create_access_state.addable_fields)
+        field_names = [field.field for field in fields]
+        for application_field in fields:
+            field_names.extend(
+                backing_field.field
+                for backing_field in get_generic_foreign_key_backing_fields(application_field)
+            )
+        return list(dict.fromkeys(field_names))
 
     def get_model_form_field_names(self) -> list[str]:
         field_names: list[str] = []
-        for application_field in self.create_access_state.addable_fields:
+        editable_field_names = self.get_layout_editable_field_names()
+        application_fields = ApplicationField.objects.filter(
+            content_type=self.get_layout_content_type(),
+            field__in=editable_field_names,
+        )
+        for application_field in application_fields:
             field_type = application_field.get_field_type_enum().value
             if field_type.editable_without_form_field and not field_type.allow_in_model:
                 continue

--- a/bloomerp/django_bloomerp/bloomerp/views/mixins/layout_form_mixin.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/mixins/layout_form_mixin.py
@@ -121,6 +121,21 @@ class BloomerpLayoutFormMixin(ABC):
 
     def get_submitted_layout_field_value(self, application_field: ApplicationField):
         field_type = application_field.get_field_type_enum().value
+        if field_type.id == "GenericForeignKey":
+            submitted_data = self.get_one_to_many_submitted_data_source()
+            if submitted_data is None:
+                return self.no_submitted_layout_value
+            try:
+                generic_foreign_key = application_field._get_model_field()
+            except Exception:
+                return self.no_submitted_layout_value
+            if generic_foreign_key.ct_field not in submitted_data and generic_foreign_key.fk_field not in submitted_data:
+                return self.no_submitted_layout_value
+            return {
+                "content_type_id": submitted_data.get(generic_foreign_key.ct_field, ""),
+                "object_id": submitted_data.get(generic_foreign_key.fk_field, ""),
+            }
+
         if field_type.id != "OneToManyField":
             return self.no_submitted_layout_value
 

--- a/bloomerp/django_bloomerp/bloomerp/widgets/generic_foreign_key_widget.py
+++ b/bloomerp/django_bloomerp/bloomerp/widgets/generic_foreign_key_widget.py
@@ -1,0 +1,53 @@
+from typing import Any
+
+from django.contrib.contenttypes.models import ContentType
+from django.db.models import Model
+from django.forms import widgets
+from django.urls import reverse
+
+from bloomerp.services.object_services import get_object_detail_url
+from bloomerp.utils.labels import safe_object_label
+
+
+class GenericForeignKeyWidget(widgets.Widget):
+    """Select one permission-visible object and submit its generic relation keys."""
+
+    template_name = "widgets/generic_foreign_key_widget.html"
+
+    def __init__(self, attrs: dict[str, Any] | None = None):
+        attrs = attrs.copy() if attrs else {}
+        self.content_type_field_name = attrs.pop("content_type_field_name", "content_type")
+        self.object_id_field_name = attrs.pop("object_id_field_name", "object_id")
+        super().__init__(attrs)
+
+    def get_context(self, name: str, value: Any, attrs: dict[str, Any] | None):
+        context = super().get_context(name, value, attrs)
+        selected_object = value if isinstance(value, Model) else None
+        content_type_id = ""
+        object_id = ""
+        selected_label = ""
+        selected_url = ""
+
+        if selected_object is not None:
+            content_type_id = str(ContentType.objects.get_for_model(selected_object).pk)
+            object_id = str(selected_object.pk)
+            selected_label = safe_object_label(selected_object)
+            selected_url = get_object_detail_url(selected_object)
+        elif isinstance(value, dict):
+            content_type_id = str(value.get("content_type_id") or "")
+            object_id = str(value.get("object_id") or "")
+            selected_label = str(value.get("label") or object_id)
+            selected_url = str(value.get("detail_url") or "")
+
+        context.update(
+            {
+                "content_type_field_name": self.content_type_field_name,
+                "object_id_field_name": self.object_id_field_name,
+                "selected_content_type_id": content_type_id,
+                "selected_object_id": object_id,
+                "selected_label": selected_label,
+                "selected_url": selected_url,
+                "search_url": reverse("components_search_content_objects"),
+            }
+        )
+        return context


### PR DESCRIPTION
## Context

Standalone feature request (no backend Todo ID): replace separate generic relation inputs with one searchable Content Object widget.

## What changed

- add a reusable `GenericForeignKeyWidget` that searches across model types and writes both the content type and object ID backing fields
- filter cross-model results through the same accessible-model and row-policy rules used by global search
- expose GenericForeignKey fields in create/detail layouts while hiding their backing fields
- persist the widget values through generic create and overview flows
- add Content Object to the Todo overview layout
- preserve object labels, detail links, previews, disabled state, and HTMX/component lifecycle behavior

## Impact

Users can select any permission-visible object from a single Content Object control. The implementation is generic and respects custom `GenericForeignKey` backing field names.

## Validation

- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.models.test_application_field.TestApplicationField.test_generic_foreign_key_field_type_owns_widget_behavior bloomerp.tests.models.test_application_field.TestApplicationField.test_generic_foreign_key_widget_renders_selected_object bloomerp.tests.models.test_application_field.TestApplicationField.test_create_fields_replace_generic_relation_backing_fields bloomerp.tests.components.test_search_content_objects bloomerp.tests.components.test_global_search bloomerp.tests.views.test_generic_foreign_key_widget` — 24 tests passed
- focused post-refactor integration run — 8 tests passed
- `npm run build` — passed
- `npm run build:js` — passed
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py check` — passed with existing third-party model warnings

## Notes

`makemigrations --check --dry-run` reports pre-existing Meta-option drift across many unrelated models (including API keys, bookmarks, comments, files, forms, initiatives, Todo, users, and workspaces). This feature changes no database schema, so that unrelated migration was not included.