### PR TITLE
Add data view tile to tile types

### DIFF
--- a/.github/instructions/bloomerp_components.instructions.md
+++ b/.github/instructions/bloomerp_components.instructions.md
@@ -465,10 +465,10 @@ def permissions_table(request: HttpRequest) -> HttpResponse:
 
 ```python
 @router.register(
-    path="components/data_view/<int:content_type_id>/",
-    name="components_data_view",
+    path="components/dataview/<int:content_type_id>/",
+    name="components_dataview",
 )
-def data_view(request: HttpRequest, content_type_id: int) -> HttpResponse:
+def dataview(request: HttpRequest, content_type_id: int) -> HttpResponse:
     """Main data view component that renders tables, kanban, calendar, etc.
     
     Args:
@@ -620,7 +620,7 @@ Backend components work seamlessly with HTMX. Here's how:
 
 ```html
 <!-- Load a data view when page loads -->
-<div hx-get="{% url 'components_data_view' content_type_id %}"
+<div hx-get="{% url 'components_dataview' content_type_id %}"
      hx-trigger="load"
      hx-swap="outerHTML">
     Loading...

--- a/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/bulk_actions.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/bulk_actions.py
@@ -22,7 +22,7 @@ from bloomerp.utils.filters import filter_model
 from bloomerp.utils.models import get_model_and_content_type_or_404
 from bloomerp.components.objects.dataviews.dataview import (
     _apply_default_filters_to_querydict,
-    _get_data_view_type_definition,
+    _get_dataview_type_definition,
     _normalize_default_filters,
 )
 from bloomerp.utils.requests import render_message
@@ -86,10 +86,10 @@ def _bulk_permission(model: type[models.Model]) -> str:
 
 def _editable_fields(request: HttpRequest, model: type[models.Model], content_type: ContentType) -> list[ApplicationField]:
     permission_manager = UserPermissionManager(request.user)
-    data_view_fields = get_data_view_fields(
+    dataview_fields = get_data_view_fields(
         UserListViewPreference.get_or_create_for_user(request.user, content_type)
     )
-    accessible_fields = [field for field, _is_visible in data_view_fields.accessible_fields]
+    accessible_fields = [field for field, _is_visible in dataview_fields.accessible_fields]
     change_permission = create_permission_str(model, "change")
     editable_fields: list[ApplicationField] = []
 
@@ -112,7 +112,7 @@ def _editable_fields(request: HttpRequest, model: type[models.Model], content_ty
 def _filter_querydict(request: HttpRequest, preference: UserListViewPreference):
     querydict = request.GET.copy()
     reserved_keys = set(RESERVED_BULK_QUERY_KEYS)
-    definition = _get_data_view_type_definition(preference.view_type)
+    definition = _get_dataview_type_definition(preference.view_type)
     if definition is not None:
         reserved_keys |= definition.renderer_cls.get_reserved_query_params()
 
@@ -260,7 +260,7 @@ def _run_bulk_update(
 
 
 @router.register(
-    path="components/data_view/<int:content_type_id>/bulk_actions/",
+    path="components/dataview/<int:content_type_id>/bulk_actions/",
     url_name="components_bulk_actions",
 )
 def bulk_actions(request: HttpRequest, content_type_id: int) -> HttpResponse:
@@ -328,7 +328,7 @@ def bulk_actions(request: HttpRequest, content_type_id: int) -> HttpResponse:
 
 
 @router.register(
-    path="components/data_view/<int:content_type_id>/bulk_actions/field_selector/",
+    path="components/dataview/<int:content_type_id>/bulk_actions/field_selector/",
     url_name="components_bulk_actions_field_selector",
 )
 def field_selector(request: HttpRequest, content_type_id: int) -> HttpResponse:

--- a/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/dataview.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/dataview.py
@@ -1,13 +1,10 @@
-from itertools import count
 import json
 
-from django.forms import modelform_factory
 from django import forms
 from django.shortcuts import render
 from django.urls import reverse
 from django.core.exceptions import FieldDoesNotExist
 from bloomerp.components.application_fields.filters import filters_init
-from bloomerp.forms.auth import User
 from bloomerp.models.definition import ObjectAction, get_model_config
 from bloomerp.services.preference_services import PreferenceManager
 from bloomerp.utils.models import get_model_and_content_type_or_404
@@ -21,14 +18,31 @@ from bloomerp.services.permission_services import create_permission_str
 from bloomerp.services.user_services import get_data_view_fields
 from bloomerp.services.object_services import string_search_on_queryset
 from bloomerp.utils.filters import filter_model
-from bloomerp.models.users.user_list_view_preference import UserListViewPreference, ViewTypeEnum
+from bloomerp.models.users.user_list_view_preference import UserListViewPreference, DataviewType
 from bloomerp.models import ApplicationField
 from django.db.models import Model, QuerySet
 from dataclasses import dataclass
 import uuid
 from pydantic import ValidationError as PydanticValidationError
-from bloomerp.dataviews.base import DataviewPagination
+from bloomerp.dataviews.base import DataviewPagination, DataviewTypeDefinition
 from bloomerp.dataviews.base import DataviewRenderState
+
+# -----------------------------------
+# GET PARAMS
+# -----------------------------------
+class DataviewReservedQueryParams:
+    query = "q"
+    page = "page"
+    component_id = "_component_id"
+    
+    
+    def __init__(self, request: HttpRequest):
+        self.request = request
+        self.query = request.GET.get(self.query)
+        self.page = request.GET.get(self.page)
+        self.component_id = request.GET.get(self.component_id)
+        
+        
 
 
 # -----------------------------------
@@ -47,13 +61,14 @@ class DataViewQueryState:
     model: type
     preference: UserListViewPreference
     dataview_options: object | None
-    data_view_fields: object
-    data_view_render_fields: list[ApplicationField]
+    dataview_fields: object
+    dataview_render_fields: list[ApplicationField]
     avatar_field: ApplicationField | None
     queryset: QuerySet
     query: str | None
     renderer_context: dict
     count: int = 0
+    reserved_params: DataviewReservedQueryParams | None = None
 
 
 def _build_data_view_query_state(
@@ -89,15 +104,15 @@ def _build_data_view_query_state(
         )
     elif preference.content_type_id != content_type.id:
         return HttpResponse("Invalid list view preference", status=400)
-    dataview_options = _get_data_view_options(preference)
-    data_view_fields = get_data_view_fields(preference)
-    avatar_field, data_view_render_fields = _split_avatar_field(data_view_fields)
+    dataview_options = _get_dataview_options(preference)
+    dataview_fields = get_data_view_fields(preference)
+    avatar_field, dataview_render_fields = _split_avatar_field(dataview_fields)
 
     # String search if 
     if query:
         queryset = string_search_on_queryset(queryset, query)
 
-    definition = _get_data_view_type_definition(preference.view_type)
+    definition = _get_dataview_type_definition(preference.view_type)
     if definition is None:
         return HttpResponse("Invalid view type", status=400)
 
@@ -116,13 +131,13 @@ def _build_data_view_query_state(
     queryset = filter_model(Model, filter_querydict, queryset)
     queryset = _select_related_rendered_relations(
         queryset,
-        data_view_render_fields + ([avatar_field] if avatar_field else []),
+        dataview_render_fields + ([avatar_field] if avatar_field else []),
     )
     
     queryset, renderer_context = definition.renderer_cls.apply_sorting(
         queryset,
         request,
-        data_view_fields,
+        dataview_fields,
         dataview_options,
     )
 
@@ -131,21 +146,22 @@ def _build_data_view_query_state(
         model=Model,
         preference=preference,
         dataview_options=dataview_options,
-        data_view_fields=data_view_fields,
-        data_view_render_fields=data_view_render_fields,
+        dataview_fields=dataview_fields,
+        dataview_render_fields=dataview_render_fields,
         avatar_field=avatar_field,
         queryset=queryset,
         query=query,
         renderer_context=renderer_context,
-        count=queryset.count()
+        count=queryset.count(),
+        reserved_params=DataviewReservedQueryParams(request)
     )
 
 
-def _split_avatar_field(data_view_fields) -> tuple[ApplicationField | None, list[ApplicationField]]:
+def _split_avatar_field(dataview_fields) -> tuple[ApplicationField | None, list[ApplicationField]]:
     avatar_field = None
     fields = []
 
-    for field in data_view_fields.visible_fields:
+    for field in dataview_fields.visible_fields:
         if field.field == "avatar":
             avatar_field = field
             continue
@@ -175,8 +191,8 @@ def _select_related_rendered_relations(
     return queryset.select_related(*dict.fromkeys(relation_names))
 
 
-def _get_accessible_application_fields(data_view_fields) -> list[ApplicationField]:
-    return [field for field, _is_visible in data_view_fields.accessible_fields]
+def _get_accessible_application_fields(dataview_fields) -> list[ApplicationField]:
+    return [field for field, _is_visible in dataview_fields.accessible_fields]
 
 
 def _get_component_args(request:HttpRequest) -> dict[str, str]:
@@ -204,9 +220,9 @@ def _get_actions(model:type[Model]) -> list[ObjectAction]:
     return []
 
 
-def _get_data_view_type_definition(view_type: str):
+def _get_dataview_type_definition(view_type: str) -> DataviewTypeDefinition:
     try:
-        return ViewTypeEnum.from_key(view_type)
+        return DataviewType.from_key(view_type)
     except ValueError:
         return None
 
@@ -255,22 +271,22 @@ def _apply_default_filters_to_querydict(
     return merged
 
 
-def _get_data_view_options_initial(preference: UserListViewPreference, view_type: str) -> dict:
-    definition = _get_data_view_type_definition(view_type)
+def _get_dataview_options_initial(preference: UserListViewPreference, view_type: str) -> dict:
+    definition = _get_dataview_type_definition(view_type)
     if definition is None:
         return {}
 
-    dataview_options = _get_data_view_options(preference, view_type)
+    dataview_options = _get_dataview_options(preference, view_type)
     if dataview_options is None:
         return {}
     return dataview_options.model_dump()
 
 
-def _get_data_view_options(preference: UserListViewPreference, view_type: str | None = None):
+def _get_dataview_options(preference: UserListViewPreference, view_type: str | None = None):
     """Returns the data view options for a specific preference type
     """
     view_type = view_type or preference.view_type
-    definition = _get_data_view_type_definition(view_type)
+    definition = _get_dataview_type_definition(view_type)
     if definition is None:
         return None
 
@@ -282,26 +298,26 @@ def _get_data_view_options(preference: UserListViewPreference, view_type: str | 
         return options_model.model_validate({})
 
 
-def _get_data_view_options_form(
+def _get_dataview_options_form(
     preference: UserListViewPreference,
     accessible_fields: list[ApplicationField],
     request: HttpRequest,
 ) -> forms.Form | None:
-    definition = _get_data_view_type_definition(preference.view_type)
+    definition = _get_dataview_type_definition(preference.view_type)
     if definition is None or not definition.opts:
         return None
 
     form_cls = definition.create_opts_form(accessible_fields)
-    return form_cls(initial=_get_data_view_options_initial(preference, definition.key))
+    return form_cls(initial=_get_dataview_options_initial(preference, definition.key))
 
 
-def _render_data_view_body(
+def _render_dataview_body(
     request: HttpRequest,
     state: DataViewQueryState,
     pagination: DataviewPagination,
     context: dict,
 ) -> str:
-    definition = _get_data_view_type_definition(state.preference.view_type)
+    definition = _get_dataview_type_definition(state.preference.view_type)
     if definition is None:
         return ""
 
@@ -312,8 +328,8 @@ def _render_data_view_body(
         model=state.model,
         preference=state.preference,
         queryset=state.queryset,
-        fields=state.data_view_fields,
-        render_fields=state.data_view_render_fields,
+        fields=state.dataview_fields,
+        render_fields=state.dataview_render_fields,
         avatar_field=state.avatar_field,
         options=state.dataview_options,
         object_actions=context.get("object_actions", []),
@@ -326,10 +342,10 @@ def _render_data_view_body(
 # Components
 # -----------------------------------
 @router.register(
-    path="components/data_view/<int:content_type_id>/",
-    name="components_data_view",
+    path="components/dataview/<int:content_type_id>/",
+    name="components_dataview",
 )
-def data_view(
+def dataview(
     request: HttpRequest,
     content_type_id: int,
     preference: UserListViewPreference | None = None,
@@ -346,7 +362,7 @@ def data_view(
     if isinstance(state, HttpResponse):
         return state
     
-    definition = _get_data_view_type_definition(state.preference.view_type)
+    definition = _get_dataview_type_definition(state.preference.view_type)
     if definition is None:
         return HttpResponse("Invalid view type", status=400)
 
@@ -376,7 +392,7 @@ def data_view(
     component_id = request.GET.get('_component_id')
 
     data_view_base_url = reverse(
-        "components_data_view",
+        "components_dataview",
         kwargs={"content_type_id": content_type_id},
     )
     data_view_querystring = request.GET.urlencode()
@@ -390,8 +406,8 @@ def data_view(
         'content_type_id': content_type_id,
         'queryset': pagination.queryset,
         'page_obj': pagination.page_obj,
-        'fields': state.data_view_fields,
-        'data_view_render_fields': state.data_view_render_fields,
+        'fields': state.dataview_fields,
+        'dataview_render_fields': state.dataview_render_fields,
         'avatar_field': state.avatar_field,
         'preference': state.preference,
         'render_id': str(uuid.uuid4()),
@@ -407,10 +423,10 @@ def data_view(
         'component_id': component_id,
         'component_args' : _get_component_args(request),
         'object_actions' : _get_actions(state.queryset.model),
-        'view_types' : [vt.value for vt in ViewTypeEnum],
-        'dataview_options_form': _get_data_view_options_form(
+        'view_types' : [vt.value for vt in DataviewType],
+        'dataview_options_form': _get_dataview_options_form(
             state.preference,
-            _get_accessible_application_fields(state.data_view_fields),
+            _get_accessible_application_fields(state.dataview_fields),
             request,
         ),
         'data_view_base_url': data_view_base_url,
@@ -421,22 +437,22 @@ def data_view(
         'count' : state.count,
     }
     context.update(state.renderer_context)
-    context["rendered_dataview"] = _render_data_view_body(request, state, pagination, context)
+    context["rendered_dataview"] = _render_dataview_body(request, state, pagination, context)
     
     return render(request, 'components/objects/dataview.html', context)
 
 
 @router.register(
-    path="components/data_view/<int:content_type_id>/action/<str:action>/",
-    name="components_data_view_action",
+    path="components/dataview/<int:content_type_id>/action/<str:action>/",
+    name="components_dataview_action",
 )
-def data_view_action(request: HttpRequest, content_type_id: int, action: str) -> HttpResponse:
+def dataview_action(request: HttpRequest, content_type_id: int, action: str) -> HttpResponse:
     """Dispatches a view-specific dataview action to the active renderer."""
     state = _build_data_view_query_state(request, content_type_id)
     if isinstance(state, HttpResponse):
         return state
 
-    definition = _get_data_view_type_definition(state.preference.view_type)
+    definition = _get_dataview_type_definition(state.preference.view_type)
     if definition is None:
         return HttpResponse("Invalid view type", status=400)
 

--- a/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/dataview.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/dataview.py
@@ -3,9 +3,8 @@ import json
 
 from django.forms import modelform_factory
 from django import forms
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import render
 from django.urls import reverse
-from django.middleware.csrf import get_token
 from django.core.exceptions import FieldDoesNotExist
 from bloomerp.components.application_fields.filters import filters_init
 from bloomerp.forms.auth import User
@@ -20,7 +19,6 @@ from django.contrib.contenttypes.models import ContentType
 from bloomerp.services.permission_services import UserPermissionManager
 from bloomerp.services.permission_services import create_permission_str
 from bloomerp.services.user_services import get_data_view_fields
-from bloomerp.services.user_services import toggle_field_visibility
 from bloomerp.services.object_services import string_search_on_queryset
 from bloomerp.utils.filters import filter_model
 from bloomerp.models.users.user_list_view_preference import UserListViewPreference, ViewTypeEnum
@@ -297,130 +295,6 @@ def _get_data_view_options_form(
     return form_cls(initial=_get_data_view_options_initial(preference, definition.key))
 
 
-def _render_display_options(
-    request: HttpRequest,
-    content_type_id: int,
-    preference: UserListViewPreference,
-) -> HttpResponse:
-    data_view_fields = get_data_view_fields(preference)
-    return render(
-        request,
-        "cotton/features/dataviews/display_options.html",
-        {
-            "content_type_id": content_type_id,
-            "view_types": [vt.value for vt in ViewTypeEnum],
-            "preference": preference,
-            "fields": data_view_fields,
-            "accessible_fields": _get_accessible_application_fields(data_view_fields),
-            "dataview_options_form": _get_data_view_options_form(
-                preference,
-                _get_accessible_application_fields(data_view_fields),
-                request,
-            ),
-            "csrf_token": get_token(request),
-        },
-    )
-
-
-def _get_preference_operation(post_data) -> str | None:
-    if "view_type" in post_data:
-        return "change_type"
-    if "split_view_enabled" in post_data:
-        return "split_view"
-    if "dataview_options_view_type" in post_data:
-        return "opt"
-    if "toggle_field_id" in post_data:
-        return "field"
-    if "default_filters" in post_data:
-        return "default_filters"
-    return None
-
-
-def _change_default_filters(preference: UserListViewPreference, post_data) -> HttpResponse | None:
-    try:
-        payload = json.loads(post_data.get("default_filters") or "{}")
-    except json.JSONDecodeError:
-        return HttpResponse("Invalid default filters", status=400)
-
-    preference.default_filters = _normalize_default_filters(payload)
-    preference.save(update_fields=["default_filters"])
-    return None
-
-
-def _change_data_view_type(preference: UserListViewPreference, post_data) -> HttpResponse | None:
-    view_type = post_data["view_type"]
-    if _get_data_view_type_definition(view_type) is None:
-        return HttpResponse("Invalid view type", status=400)
-
-    preference.view_type = view_type
-    preference.save(update_fields=["view_type"])
-    return None
-
-
-def _change_split_view(preference: UserListViewPreference, post_data) -> HttpResponse | None:
-    preference.split_view_enabled = str(post_data["split_view_enabled"]).lower() == "true"
-    preference.save(update_fields=["split_view_enabled"])
-    return None
-
-
-def _change_data_view_options(
-    preference: UserListViewPreference,
-    data_view_fields,
-    post_data,
-) -> HttpResponse | None:
-    view_type = post_data["dataview_options_view_type"]
-    if view_type != preference.view_type:
-        return HttpResponse("Invalid options view type", status=400)
-
-    definition = _get_data_view_type_definition(view_type)
-    if definition is None:
-        return HttpResponse("Invalid view type", status=400)
-
-    form_cls = definition.create_opts_form(data_view_fields)
-    form = form_cls(post_data)
-    if not form.is_valid():
-        return HttpResponse("Invalid options", status=400)
-
-    options = dict(preference.options or {})
-    option_model = definition.get_options_model()
-    try:
-        options[view_type] = option_model.model_validate(form.cleaned_data).model_dump()
-    except PydanticValidationError as error:
-        return HttpResponse(f"Invalid options: {error}", status=400)
-
-    preference.options = options
-    preference.save(update_fields=["options"])
-    return None
-
-
-def _change_data_view_field_visibility(
-    request: HttpRequest,
-    content_type: ContentType,
-    preference: UserListViewPreference,
-    post_data,
-) -> HttpResponse | None:
-    try:
-        field_id = int(post_data["toggle_field_id"])
-        view_type = post_data.get("toggle_view_type", preference.view_type)
-        if _get_data_view_type_definition(view_type) is None:
-            return HttpResponse("Invalid view type", status=400)
-
-        permission_manager = UserPermissionManager(request.user)
-        application_field = ApplicationField.objects.get(id=field_id)
-
-        if not permission_manager.has_field_permission(
-            application_field,
-            create_permission_str(content_type.model_class(), "view")
-        ):
-            return HttpResponse("Permission denied", status=403)
-
-        toggle_field_visibility(request.user, content_type, field_id, view_type)
-    except (ValueError, ApplicationField.DoesNotExist) as e:
-        return HttpResponse(f"Invalid field: {e}", status=400)
-
-    return None
-
-
 def _render_data_view_body(
     request: HttpRequest,
     state: DataViewQueryState,
@@ -569,55 +443,3 @@ def data_view_action(request: HttpRequest, content_type_id: int, action: str) ->
     return definition.renderer_cls.handle_action(action, request, state)
     
 
-@router.register(
-    path="components/change_data_view_preference/<int:content_type_id>/",
-    name="components_change_data_view_preference",
-)
-def change_data_view_preference(request: HttpRequest, content_type_id: int) -> HttpResponse:
-    """Changes the datatable preference
-
-    Args:
-        request (HttpRequest): the request object
-        content_type_id (int): The content type ID
-
-    Returns:
-        HttpResponse: the rendered datatable with the different preferences
-    """
-    if request.method != "POST":
-        return HttpResponse("Method not allowed", status=405)
-    
-    # Get the content type, user, and list view preference
-    content_type = get_object_or_404(ContentType, id=content_type_id)
-    user = request.user
-    manager = PreferenceManager(user)
-    preference = manager.get_or_create_selected(UserListViewPreference, {
-        "content_type_id": content_type.id,
-    })
-    
-    if not manager.can_manage(preference):
-        return HttpResponse("Forbidden", status=403)
-    
-    operation = _get_preference_operation(request.POST)
-    match operation:
-        case "change_type":
-            error_response = _change_data_view_type(preference, request.POST)
-        case "split_view":
-            error_response = _change_split_view(preference, request.POST)
-        case "opt":
-            data_view_fields = get_data_view_fields(preference)
-            error_response = _change_data_view_options(
-                preference,
-                _get_accessible_application_fields(data_view_fields),
-                request.POST,
-            )
-        case "field":
-            error_response = _change_data_view_field_visibility(request, content_type, preference, request.POST)
-        case "default_filters":
-            error_response = _change_default_filters(preference, request.POST)
-        case _:
-            error_response = None
-
-    if error_response is not None:
-        return error_response
-    
-    return _render_display_options(request, content_type_id, preference)

--- a/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/dataview.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/dataview.py
@@ -58,12 +58,17 @@ class DataViewQueryState:
     count: int = 0
 
 
-def _build_data_view_query_state(request: HttpRequest, content_type_id: int) -> DataViewQueryState | HttpResponse:
+def _build_data_view_query_state(
+    request: HttpRequest,
+    content_type_id: int,
+    preference: UserListViewPreference | None = None,
+) -> DataViewQueryState | HttpResponse:
     """Builds the dataview query state
 
     Args:
         request (HttpRequest): the request object
         content_type_id (int): the content type id
+        preference: An explicit available preference, or the user's selected preference.
 
     Returns:
         DataViewQueryState | HttpResponse: _description_
@@ -79,9 +84,13 @@ def _build_data_view_query_state(request: HttpRequest, content_type_id: int) -> 
     queryset = permission_manager.get_queryset(Model, create_permission_str(Model, "view"))
     
     # Get preference and options
-    preference = PreferenceManager(request.user).get_or_create_selected(UserListViewPreference, {
-        "content_type_id": content_type.id,
-    })
+    if preference is None:
+        preference = PreferenceManager(request.user).get_or_create_selected(
+            UserListViewPreference,
+            {"content_type_id": content_type.id},
+        )
+    elif preference.content_type_id != content_type.id:
+        return HttpResponse("Invalid list view preference", status=400)
     dataview_options = _get_data_view_options(preference)
     data_view_fields = get_data_view_fields(preference)
     avatar_field, data_view_render_fields = _split_avatar_field(data_view_fields)
@@ -446,7 +455,11 @@ def _render_data_view_body(
     path="components/data_view/<int:content_type_id>/",
     name="components_data_view",
 )
-def data_view(request: HttpRequest, content_type_id: int) -> HttpResponse:
+def data_view(
+    request: HttpRequest,
+    content_type_id: int,
+    preference: UserListViewPreference | None = None,
+) -> HttpResponse:
     """
     Renders the data table component. A data table is a table that takes in a content type 
     id and renders a table of the corresponding model's data.
@@ -455,7 +468,7 @@ def data_view(request: HttpRequest, content_type_id: int) -> HttpResponse:
     - permissions management
     - string searching
     """
-    state = _build_data_view_query_state(request, content_type_id)
+    state = _build_data_view_query_state(request, content_type_id, preference)
     if isinstance(state, HttpResponse):
         return state
     

--- a/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/update_preference.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/update_preference.py
@@ -1,0 +1,191 @@
+from django.middleware.csrf import get_token
+from pydantic import ValidationError as PydanticValidationError
+
+from bloomerp.components.objects.dataviews.dataview import _get_accessible_application_fields, _get_data_view_options_form, _get_data_view_type_definition, _normalize_default_filters
+from bloomerp.models import ApplicationField
+from bloomerp.models.users.user_list_view_preference import UserListViewPreference, ViewTypeEnum
+from bloomerp.router import router
+from bloomerp.services.permission_services import UserPermissionManager, create_permission_str
+from bloomerp.services.preference_services import PreferenceManager
+from bloomerp.services.user_services import get_data_view_fields, toggle_field_visibility
+from django.contrib.contenttypes.models import ContentType
+from django.http import HttpRequest, HttpResponse
+from django.shortcuts import get_object_or_404, render
+
+
+def _change_data_view_field_visibility(
+    request: HttpRequest,
+    content_type: ContentType,
+    preference: UserListViewPreference,
+    post_data,
+) -> HttpResponse | None:
+    try:
+        field_id = int(post_data["toggle_field_id"])
+        view_type = post_data.get("toggle_view_type", preference.view_type)
+        if _get_data_view_type_definition(view_type) is None:
+            return HttpResponse("Invalid view type", status=400)
+
+        permission_manager = UserPermissionManager(request.user)
+        application_field = ApplicationField.objects.get(id=field_id)
+
+        if not permission_manager.has_field_permission(
+            application_field,
+            create_permission_str(content_type.model_class(), "view")
+        ):
+            return HttpResponse("Permission denied", status=403)
+
+        toggle_field_visibility(request.user, content_type, field_id, view_type)
+    except (ValueError, ApplicationField.DoesNotExist) as e:
+        return HttpResponse(f"Invalid field: {e}", status=400)
+
+    return None
+
+
+def _change_data_view_options(
+    preference: UserListViewPreference,
+    data_view_fields,
+    post_data,
+) -> HttpResponse | None:
+    view_type = post_data["dataview_options_view_type"]
+    if view_type != preference.view_type:
+        return HttpResponse("Invalid options view type", status=400)
+
+    definition = _get_data_view_type_definition(view_type)
+    if definition is None:
+        return HttpResponse("Invalid view type", status=400)
+
+    form_cls = definition.create_opts_form(data_view_fields)
+    form = form_cls(post_data)
+    if not form.is_valid():
+        return HttpResponse("Invalid options", status=400)
+
+    options = dict(preference.options or {})
+    option_model = definition.get_options_model()
+    try:
+        options[view_type] = option_model.model_validate(form.cleaned_data).model_dump()
+    except PydanticValidationError as error:
+        return HttpResponse(f"Invalid options: {error}", status=400)
+
+    preference.options = options
+    preference.save(update_fields=["options"])
+    return None
+
+
+def _change_split_view(preference: UserListViewPreference, post_data) -> HttpResponse | None:
+    preference.split_view_enabled = str(post_data["split_view_enabled"]).lower() == "true"
+    preference.save(update_fields=["split_view_enabled"])
+    return None
+
+
+def _change_data_view_type(preference: UserListViewPreference, post_data) -> HttpResponse | None:
+    view_type = post_data["view_type"]
+    if _get_data_view_type_definition(view_type) is None:
+        return HttpResponse("Invalid view type", status=400)
+
+    preference.view_type = view_type
+    preference.save(update_fields=["view_type"])
+    return None
+
+
+def _render_display_options(
+    request: HttpRequest,
+    content_type_id: int,
+    preference: UserListViewPreference,
+) -> HttpResponse:
+    data_view_fields = get_data_view_fields(preference)
+    return render(
+        request,
+        "cotton/features/dataviews/display_options.html",
+        {
+            "content_type_id": content_type_id,
+            "view_types": [vt.value for vt in ViewTypeEnum],
+            "preference": preference,
+            "fields": data_view_fields,
+            "accessible_fields": _get_accessible_application_fields(data_view_fields),
+            "dataview_options_form": _get_data_view_options_form(
+                preference,
+                _get_accessible_application_fields(data_view_fields),
+                request,
+            ),
+            "csrf_token": get_token(request),
+        },
+    )
+
+
+def _get_preference_operation(post_data) -> str | None:
+    if "view_type" in post_data:
+        return "change_type"
+    if "split_view_enabled" in post_data:
+        return "split_view"
+    if "dataview_options_view_type" in post_data:
+        return "opt"
+    if "toggle_field_id" in post_data:
+        return "field"
+    if "default_filters" in post_data:
+        return "default_filters"
+    return None
+
+
+def _change_default_filters(preference: UserListViewPreference, post_data) -> HttpResponse | None:
+    try:
+        payload = json.loads(post_data.get("default_filters") or "{}")
+    except json.JSONDecodeError:
+        return HttpResponse("Invalid default filters", status=400)
+
+    preference.default_filters = _normalize_default_filters(payload)
+    preference.save(update_fields=["default_filters"])
+    return None
+
+
+@router.register(
+    path="components/change_data_view_preference/<int:content_type_id>/",
+    name="components_update_dataview_preference",
+)
+def update_dataview_preference(request: HttpRequest, content_type_id: int) -> HttpResponse:
+    """Changes the dataview preference
+
+    Args:
+        request (HttpRequest): the request object
+        content_type_id (int): The content type ID
+
+    Returns:
+        HttpResponse: the rendered datatable with the different preferences
+    """
+    if request.method != "POST":
+        return HttpResponse("Method not allowed", status=405)
+
+    # Get the content type, user, and list view preference
+    content_type = get_object_or_404(ContentType, id=content_type_id)
+    user = request.user
+    manager = PreferenceManager(user)
+    preference = manager.get_or_create_selected(UserListViewPreference, {
+        "content_type_id": content_type.id,
+    })
+
+    if not manager.can_manage(preference):
+        return HttpResponse("Forbidden", status=403)
+
+    operation = _get_preference_operation(request.POST)
+    match operation:
+        case "change_type":
+            error_response = _change_data_view_type(preference, request.POST)
+        case "split_view":
+            error_response = _change_split_view(preference, request.POST)
+        case "opt":
+            data_view_fields = get_data_view_fields(preference)
+            error_response = _change_data_view_options(
+                preference,
+                _get_accessible_application_fields(data_view_fields),
+                request.POST,
+            )
+        case "field":
+            error_response = _change_data_view_field_visibility(request, content_type, preference, request.POST)
+        case "default_filters":
+            error_response = _change_default_filters(preference, request.POST)
+        case _:
+            error_response = None
+
+    if error_response is not None:
+        return error_response
+
+    return _render_display_options(request, content_type_id, preference)

--- a/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/update_preference.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/update_preference.py
@@ -1,9 +1,9 @@
 from django.middleware.csrf import get_token
 from pydantic import ValidationError as PydanticValidationError
 
-from bloomerp.components.objects.dataviews.dataview import _get_accessible_application_fields, _get_data_view_options_form, _get_data_view_type_definition, _normalize_default_filters
+from bloomerp.components.objects.dataviews.dataview import _get_accessible_application_fields, _get_dataview_options_form, _get_dataview_type_definition, _normalize_default_filters
 from bloomerp.models import ApplicationField
-from bloomerp.models.users.user_list_view_preference import UserListViewPreference, ViewTypeEnum
+from bloomerp.models.users.user_list_view_preference import UserListViewPreference, DataviewType
 from bloomerp.router import router
 from bloomerp.services.permission_services import UserPermissionManager, create_permission_str
 from bloomerp.services.preference_services import PreferenceManager
@@ -22,7 +22,7 @@ def _change_data_view_field_visibility(
     try:
         field_id = int(post_data["toggle_field_id"])
         view_type = post_data.get("toggle_view_type", preference.view_type)
-        if _get_data_view_type_definition(view_type) is None:
+        if _get_dataview_type_definition(view_type) is None:
             return HttpResponse("Invalid view type", status=400)
 
         permission_manager = UserPermissionManager(request.user)
@@ -43,18 +43,18 @@ def _change_data_view_field_visibility(
 
 def _change_data_view_options(
     preference: UserListViewPreference,
-    data_view_fields,
+    dataview_fields,
     post_data,
 ) -> HttpResponse | None:
     view_type = post_data["dataview_options_view_type"]
     if view_type != preference.view_type:
         return HttpResponse("Invalid options view type", status=400)
 
-    definition = _get_data_view_type_definition(view_type)
+    definition = _get_dataview_type_definition(view_type)
     if definition is None:
         return HttpResponse("Invalid view type", status=400)
 
-    form_cls = definition.create_opts_form(data_view_fields)
+    form_cls = definition.create_opts_form(dataview_fields)
     form = form_cls(post_data)
     if not form.is_valid():
         return HttpResponse("Invalid options", status=400)
@@ -79,7 +79,7 @@ def _change_split_view(preference: UserListViewPreference, post_data) -> HttpRes
 
 def _change_data_view_type(preference: UserListViewPreference, post_data) -> HttpResponse | None:
     view_type = post_data["view_type"]
-    if _get_data_view_type_definition(view_type) is None:
+    if _get_dataview_type_definition(view_type) is None:
         return HttpResponse("Invalid view type", status=400)
 
     preference.view_type = view_type
@@ -92,19 +92,19 @@ def _render_display_options(
     content_type_id: int,
     preference: UserListViewPreference,
 ) -> HttpResponse:
-    data_view_fields = get_data_view_fields(preference)
+    dataview_fields = get_data_view_fields(preference)
     return render(
         request,
         "cotton/features/dataviews/display_options.html",
         {
             "content_type_id": content_type_id,
-            "view_types": [vt.value for vt in ViewTypeEnum],
+            "view_types": [vt.value for vt in DataviewType],
             "preference": preference,
-            "fields": data_view_fields,
-            "accessible_fields": _get_accessible_application_fields(data_view_fields),
-            "dataview_options_form": _get_data_view_options_form(
+            "fields": dataview_fields,
+            "accessible_fields": _get_accessible_application_fields(dataview_fields),
+            "dataview_options_form": _get_dataview_options_form(
                 preference,
-                _get_accessible_application_fields(data_view_fields),
+                _get_accessible_application_fields(dataview_fields),
                 request,
             ),
             "csrf_token": get_token(request),
@@ -172,10 +172,10 @@ def update_dataview_preference(request: HttpRequest, content_type_id: int) -> Ht
         case "split_view":
             error_response = _change_split_view(preference, request.POST)
         case "opt":
-            data_view_fields = get_data_view_fields(preference)
+            dataview_fields = get_data_view_fields(preference)
             error_response = _change_data_view_options(
                 preference,
-                _get_accessible_application_fields(data_view_fields),
+                _get_accessible_application_fields(dataview_fields),
                 request.POST,
             )
         case "field":

--- a/bloomerp/django_bloomerp/bloomerp/components/workspaces/preview_workspace_tile.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/workspaces/preview_workspace_tile.py
@@ -140,7 +140,10 @@ class PreviewWorkspaceTile(TemplateView):
             True
         )
         if self.get_tile_type().value.form_cls:
-            ctx["form"] = self.get_tile_type().value.form_cls()
+            form_kwargs = {"initial": config.model_dump()}
+            if self.get_tile_type() == TileType.DATAVIEW_TILE:
+                form_kwargs["user"] = self.request.user
+            ctx["form"] = self.get_tile_type().value.form_cls(**form_kwargs)
         
         return ctx
     
@@ -153,8 +156,6 @@ class PreviewWorkspaceTile(TemplateView):
                 return "components/workspaces/tile_builders/links_tile_builder.html"
             case TileType.TEXT_TILE:
                 return "components/workspaces/tile_builders/text_tile_builder.html"
-            # case TileType.DATAVIEW_TILE:
-            #     return "components/workspaces/tile_builders/dataview_tile_builder.html"
             # case TileType.FORM_TILE:
             #     return "components/workspaces/tile_builders/form_tile_builder.html"
             case _:
@@ -277,8 +278,11 @@ class PreviewWorkspaceTile(TemplateView):
         try:
             # Get the new configuration based on the handler
             
-            if isinstance(operation_def.validation_model, forms.Form):
-                data = operation_def.validation_model(data=request.POST, files=request.FILES)
+            if issubclass(operation_def.validation_model, forms.Form):
+                form_kwargs = {"data": request.POST, "files": request.FILES}
+                if tile_type == TileType.DATAVIEW_TILE:
+                    form_kwargs["user"] = request.user
+                data = operation_def.validation_model(**form_kwargs)
             else:
                 data = operation_def.validation_model(**data)
             

--- a/bloomerp/django_bloomerp/bloomerp/dataviews/base.py
+++ b/bloomerp/django_bloomerp/bloomerp/dataviews/base.py
@@ -107,7 +107,7 @@ class BaseDataviewRenderer:
         return HttpResponse(f"Unsupported dataview action: {action}", status=400)
 
     @staticmethod
-    def get_field_from_data_view_fields(data_view_fields, field_id):
+    def get_field_from_data_view_fields(dataview_fields, field_id):
         if field_id in (None, ""):
             return None
 
@@ -116,11 +116,11 @@ class BaseDataviewRenderer:
         except (TypeError, ValueError):
             return None
 
-        for field, _is_visible in getattr(data_view_fields, "accessible_fields", []):
+        for field, _is_visible in getattr(dataview_fields, "accessible_fields", []):
             if field.id == field_id:
                 return field
 
-        for field in getattr(data_view_fields, "visible_fields", []):
+        for field in getattr(dataview_fields, "visible_fields", []):
             if field.id == field_id:
                 return field
 

--- a/bloomerp/django_bloomerp/bloomerp/dataviews/calendar.py
+++ b/bloomerp/django_bloomerp/bloomerp/dataviews/calendar.py
@@ -112,16 +112,16 @@ class CalendarDataviewRenderer(BaseDataviewRenderer):
         return context
 
     @classmethod
-    def get_start_field(cls, data_view_fields, options):
+    def get_start_field(cls, dataview_fields, options):
         return cls.get_field_from_data_view_fields(
-            data_view_fields,
+            dataview_fields,
             getattr(options, "start_field_id", None),
         )
 
     @classmethod
-    def get_end_field(cls, data_view_fields, options):
+    def get_end_field(cls, dataview_fields, options):
         return cls.get_field_from_data_view_fields(
-            data_view_fields,
+            dataview_fields,
             getattr(options, "end_field_id", None),
         )
 

--- a/bloomerp/django_bloomerp/bloomerp/dataviews/kanban.py
+++ b/bloomerp/django_bloomerp/bloomerp/dataviews/kanban.py
@@ -50,9 +50,9 @@ class KanbanDataviewRenderer(BaseDataviewRenderer):
         return cls.build_querystring(request, ("page", "kanban_page", "kanban_column"))
 
     @classmethod
-    def get_group_by_field(cls, data_view_fields, options):
+    def get_group_by_field(cls, dataview_fields, options):
         return cls.get_field_from_data_view_fields(
-            data_view_fields,
+            dataview_fields,
             getattr(options, "group_by_field_id", None),
         )
 
@@ -62,7 +62,7 @@ class KanbanDataviewRenderer(BaseDataviewRenderer):
             return super().handle_action(action, request, state)
 
         group_by_field = cls.get_group_by_field(
-            state.data_view_fields,
+            state.dataview_fields,
             state.dataview_options,
         )
         if not group_by_field:
@@ -88,7 +88,7 @@ class KanbanDataviewRenderer(BaseDataviewRenderer):
             "components/objects/dataview_kanban_cards.html",
             {
                 "content_type_id": state.content_type.id,
-                "fields": state.data_view_render_fields,
+                "fields": state.dataview_render_fields,
                 "avatar_field": state.avatar_field,
                 "group": group,
                 "kanban_page_querystring": cls.build_page_querystring(request),

--- a/bloomerp/django_bloomerp/bloomerp/dataviews/table.py
+++ b/bloomerp/django_bloomerp/bloomerp/dataviews/table.py
@@ -23,16 +23,16 @@ class TableDataviewRenderer(BaseDataviewRenderer):
         return context
 
     @staticmethod
-    def _get_sortable_fields_by_name(data_view_fields) -> dict:
-        if hasattr(data_view_fields, "accessible_fields"):
+    def _get_sortable_fields_by_name(dataview_fields) -> dict:
+        if hasattr(dataview_fields, "accessible_fields"):
             return {
                 field.field: field
-                for field, _is_visible in data_view_fields.accessible_fields
+                for field, _is_visible in dataview_fields.accessible_fields
             }
 
         return {
             field.field: field
-            for field in data_view_fields.visible_fields
+            for field in dataview_fields.visible_fields
         }
 
     @classmethod
@@ -40,12 +40,12 @@ class TableDataviewRenderer(BaseDataviewRenderer):
         cls,
         queryset: QuerySet,
         request: HttpRequest,
-        data_view_fields,
+        dataview_fields,
         options: object | None = None,
     ) -> tuple[QuerySet, dict]:
         sort_field = request.GET.get("sort") or getattr(options, "sort_field", None)
         sort_direction = request.GET.get("direction") or getattr(options, "sort_direction", "asc") or "asc"
-        sortable_fields_by_name = cls._get_sortable_fields_by_name(data_view_fields)
+        sortable_fields_by_name = cls._get_sortable_fields_by_name(dataview_fields)
 
         context = {
             "current_sort_field": "",

--- a/bloomerp/django_bloomerp/bloomerp/field_types/dataview_value_functions.py
+++ b/bloomerp/django_bloomerp/bloomerp/field_types/dataview_value_functions.py
@@ -1,6 +1,5 @@
 from django.db.models import Model
 from typing import TYPE_CHECKING
-
 from django.urls import reverse
 
 from bloomerp.utils.labels import safe_object_label
@@ -69,6 +68,7 @@ def render_foreign_key_dataview_value(application_field: "ApplicationField", obj
     url = getattr(related_object, "get_absolute_url", lambda: "#")()
     name = safe_object_label(related_object)
     return f'<a href="{url}" class="text-primary hover:underline">{name}</a>'
+
 
 def render_generic_relation_value(application_field: "ApplicationField", object: Model) -> str:
     """

--- a/bloomerp/django_bloomerp/bloomerp/models/users/__init__.py
+++ b/bloomerp/django_bloomerp/bloomerp/models/users/__init__.py
@@ -1,6 +1,6 @@
 from .user import AbstractBloomerpUser, User
 from .bookmark import Bookmark
-from .user_list_view_preference import UserListViewPreference, ViewTypeEnum
+from .user_list_view_preference import UserListViewPreference, DataviewType
 from .user_detail_view_preference import UserDetailViewPreference
 from .user_create_view_preference import UserCreateViewPreference
 
@@ -9,7 +9,7 @@ __all__ = [
     'User',
     'Bookmark',
     'UserListViewPreference',
-    'ViewTypeEnum',
+    'DataviewType',
     'UserDetailViewPreference',
     'UserCreateViewPreference',
 ]

--- a/bloomerp/django_bloomerp/bloomerp/models/users/user_list_view_preference.py
+++ b/bloomerp/django_bloomerp/bloomerp/models/users/user_list_view_preference.py
@@ -40,7 +40,7 @@ def get_default_display_fields() -> dict:
               Structure: {"table": [], "kanban": [], "calendar": []}
               Each list contains ApplicationField IDs in display order.
     """
-    return {view_type.value.key: [] for view_type in ViewTypeEnum}
+    return {view_type.value.key: [] for view_type in DataviewType}
 
 
 DEFAULT_OPTION_UNSET = object()
@@ -262,7 +262,7 @@ class PivotTableDataviewOptions(BaseModel):
         return migrated
 
 
-class ViewTypeEnum(Enum):
+class DataviewType(Enum):
     TABLE = ViewTypeDefinition(
         key="table",
         label="Table",
@@ -580,8 +580,8 @@ class UserListViewPreference(BaseViewPreference):
 
     view_type = models.CharField(
         max_length=50,
-        choices=ViewTypeEnum.choices(),
-        default=ViewTypeEnum.TABLE.value.key,
+        choices=DataviewType.choices(),
+        default=DataviewType.TABLE.value.key,
     )
     split_view_enabled = models.BooleanField(default=False)
     
@@ -655,7 +655,7 @@ class UserListViewPreference(BaseViewPreference):
         Returns:
             bool: True if field visibility options should be shown, False otherwise.
         """
-        view_type_def = ViewTypeEnum.from_key(self.view_type)
+        view_type_def = DataviewType.from_key(self.view_type)
         return view_type_def.requires_display_fields
     
     

--- a/bloomerp/django_bloomerp/bloomerp/static/bloomerp/css/dist/styles.css
+++ b/bloomerp/django_bloomerp/bloomerp/static/bloomerp/css/dist/styles.css
@@ -368,6 +368,9 @@
   .top-5 {
     top: calc(var(--spacing) * 5);
   }
+  .top-11 {
+    top: calc(var(--spacing) * 11);
+  }
   .top-16 {
     top: calc(var(--spacing) * 16);
   }
@@ -412,6 +415,9 @@
   }
   .bottom-full {
     bottom: 100%;
+  }
+  .-left-7 {
+    left: calc(var(--spacing) * -7);
   }
   .-left-9 {
     left: calc(var(--spacing) * -9);
@@ -708,6 +714,9 @@
   .h-14 {
     height: calc(var(--spacing) * 14);
   }
+  .h-16 {
+    height: calc(var(--spacing) * 16);
+  }
   .h-24 {
     height: calc(var(--spacing) * 24);
   }
@@ -783,9 +792,6 @@
   .max-h-96 {
     max-height: calc(var(--spacing) * 96);
   }
-  .max-h-\[50vh\] {
-    max-height: 50vh;
-  }
   .max-h-\[52vh\] {
     max-height: 52vh;
   }
@@ -798,8 +804,8 @@
   .max-h-\[calc\(100vh-2rem\)\] {
     max-height: calc(100vh - 2rem);
   }
-  .max-h-\[vh50\] {
-    max-height: vh50;
+  .max-h-\[calc\(100vh-6rem\)\] {
+    max-height: calc(100vh - 6rem);
   }
   .max-h-full {
     max-height: 100%;
@@ -987,6 +993,9 @@
   .max-w-\[calc\(100\%-260px\)\] {
     max-width: calc(100% - 260px);
   }
+  .max-w-\[calc\(100vw-1rem\)\] {
+    max-width: calc(100vw - 1rem);
+  }
   .max-w-\[min\(28rem\,calc\(100vw-2rem\)\)\] {
     max-width: min(28rem, calc(100vw - 2rem));
   }
@@ -1007,6 +1016,9 @@
   }
   .min-w-0 {
     min-width: calc(var(--spacing) * 0);
+  }
+  .min-w-1 {
+    min-width: calc(var(--spacing) * 1);
   }
   .min-w-2 {
     min-width: calc(var(--spacing) * 2);
@@ -1040,9 +1052,6 @@
   }
   .min-w-\[12rem\] {
     min-width: 12rem;
-  }
-  .min-w-\[64rem\] {
-    min-width: 64rem;
   }
   .min-w-\[140px\] {
     min-width: 140px;
@@ -1268,9 +1277,6 @@
   }
   .grid-cols-\[minmax\(0\,1fr\)_minmax\(0\,1\.4fr\)_220px\] {
     grid-template-columns: minmax(0,1fr) minmax(0,1.4fr) 220px;
-  }
-  .grid-cols-\[minmax\(16rem\,22rem\)_minmax\(48rem\,1fr\)\] {
-    grid-template-columns: minmax(16rem,22rem) minmax(48rem,1fr);
   }
   .flex-col {
     flex-direction: column;
@@ -1559,6 +1565,14 @@
   .border-2 {
     border-style: var(--tw-border-style);
     border-width: 2px;
+  }
+  .border-x {
+    border-inline-style: var(--tw-border-style);
+    border-inline-width: 1px;
+  }
+  .border-y-0 {
+    border-block-style: var(--tw-border-style);
+    border-block-width: 0px;
   }
   .border-t {
     border-top-style: var(--tw-border-style);
@@ -2371,6 +2385,9 @@
   }
   .text-blue-800 {
     color: var(--color-blue-800);
+  }
+  .text-danger-dark {
+    color: var(--color-danger-dark);
   }
   .text-dark {
     color: var(--color-dark);
@@ -3250,6 +3267,11 @@
       opacity: 50%;
     }
   }
+  .sm\:mb-4 {
+    @media (width >= 40rem) {
+      margin-bottom: calc(var(--spacing) * 4);
+    }
+  }
   .sm\:inline {
     @media (width >= 40rem) {
       display: inline;
@@ -3323,6 +3345,11 @@
   .sm\:gap-3 {
     @media (width >= 40rem) {
       gap: calc(var(--spacing) * 3);
+    }
+  }
+  .sm\:gap-4 {
+    @media (width >= 40rem) {
+      gap: calc(var(--spacing) * 4);
     }
   }
   .md\:col-span-2 {
@@ -3443,6 +3470,11 @@
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
   }
+  .lg\:grid-cols-3 {
+    @media (width >= 64rem) {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
   .lg\:grid-cols-4 {
     @media (width >= 64rem) {
       grid-template-columns: repeat(4, minmax(0, 1fr));
@@ -3526,6 +3558,11 @@
   .xl\:grid-cols-3 {
     @media (width >= 80rem) {
       grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+  .xl\:grid-cols-4 {
+    @media (width >= 80rem) {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
     }
   }
   .xl\:grid-cols-\[minmax\(0\,1fr\)_340px\] {

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/data_view_components/DataViewContainer.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/data_view_components/DataViewContainer.ts
@@ -14,7 +14,7 @@ import { insertSkeleton } from "@/utils/animations";
 
 export class DataViewContainer extends BaseComponent {
 
-    private target:string = '#data-view-data-section'
+    private target:HTMLElement|null = null;
     private baseUrl:string|null;
     private fullPath:string|null; // Includes query parameters
     private searchInput:HTMLInputElement|null = null;
@@ -51,9 +51,13 @@ export class DataViewContainer extends BaseComponent {
         this.splitViewEnabled = this.element?.dataset.splitViewEnabled === 'True';
         this.syncUrl = this.element?.dataset.syncUrl === 'true';
 
-        this.focusSearchInput();
+        // Setup target
+        this.setDataviewTarget();
 
         // Focus on search input
+        this.focusSearchInput();
+
+        
         this.setupKeydownListeners();
 
         this.setupSplitViewFocusTargets();
@@ -171,7 +175,7 @@ export class DataViewContainer extends BaseComponent {
             this.pendingHistoryMode = pushHistory ? "push" : "replace";
         }
 
-        insertSkeleton(document.querySelector(this.target) as HTMLElement);
+        insertSkeleton(this.target);
 
         htmx.ajax('get', this.fullPath, {
             target: this.target,
@@ -644,7 +648,7 @@ export class DataViewContainer extends BaseComponent {
         if (!this.contentTypeId) return null;
 
         const currentUrl = this.getCurrentUrl();
-        const url = new URL(`/components/data_view/${this.contentTypeId}/bulk_actions/`, window.location.origin);
+        const url = new URL(`/components/dataview/${this.contentTypeId}/bulk_actions/`, window.location.origin);
         url.searchParams.set('selection', useSelection ? 'selected' : 'filtered');
         currentUrl?.searchParams.forEach((value, key) => {
             if (key === 'page') return;
@@ -870,6 +874,13 @@ export class DataViewContainer extends BaseComponent {
     public onAfterSwap(): void {
         this.bindDisplayOptionsCallback();
         this.renderDefaultFilters();
+    }
+
+    /**
+     * Sets the target element for the data view container. The target is the element where the data view content will be swapped in after an HTMX request. It looks for an element with the attribute `data-dataview-target` within the container's root element. If found, it sets `this.target` to that element; otherwise, it sets it to `null`.
+     */
+    private setDataviewTarget(): void {
+        this.target = this.element?.querySelector<HTMLElement>('#data-view-data-section') ?? null;
     }
 
     public destroy(): void {

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/utils/dataview.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/utils/dataview.ts
@@ -6,7 +6,7 @@ export default function renderDataView(
     element: HTMLElement,
     contentTypeId: number|string
 ): Promise<DataViewContainer> {
-    const url = `/components/data_view/${contentTypeId}/`;
+    const url = `/components/dataview/${contentTypeId}/`;
 
     return htmx.ajax('get', url, {
         target: `#${element.id}`,

--- a/bloomerp/django_bloomerp/bloomerp/templates/components/objects/dataview_kanban_cards.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/components/objects/dataview_kanban_cards.html
@@ -45,7 +45,7 @@
 <div
     class="py-3 text-center text-xs text-gray-400"
     data-kanban-column-loader
-    hx-get="{% url 'components_data_view_action' content_type_id=content_type_id action='column' %}{% if kanban_page_querystring %}?{{ kanban_page_querystring }}&{% else %}?{% endif %}kanban_column={{ group.request_value|urlencode }}&kanban_page={{ group.next_page_number }}"
+    hx-get="{% url 'components_dataview_action' content_type_id=content_type_id action='column' %}{% if kanban_page_querystring %}?{{ kanban_page_querystring }}&{% else %}?{% endif %}kanban_column={{ group.request_value|urlencode }}&kanban_page={{ group.next_page_number }}"
     hx-trigger="intersect once"
     hx-target="this"
     hx-swap="outerHTML"

--- a/bloomerp/django_bloomerp/bloomerp/templates/components/workspaces/tile_builders/default_tile_builder.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/components/workspaces/tile_builders/default_tile_builder.html
@@ -6,6 +6,7 @@
     hx-vals='{"csrfmiddlewaretoken": "{{ csrf_token }}"}'
     hx-vars='js:{operation: "set_form"}'
     hx-trigger="change delay:200ms"
+    hx-target="#tile-preview-section"
     >
     
     {% csrf_token %}

--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/dataviews/calendar.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/dataviews/calendar.html
@@ -25,7 +25,7 @@ Parameters:
     data-content-type-id="{{ content_type_id }}"
     data-view-mode="{{ view_mode|default:'month' }}"
     data-page-offset="{{ calendar_page_offset|default:0 }}"
-    data-url="{% url 'components_data_view' content_type_id=content_type_id %}"
+    data-url="{% url 'components_dataview' content_type_id=content_type_id %}"
 
     bloomerp-component="calendar"
 >

--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/dataviews/call.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/dataviews/call.html
@@ -1,5 +1,5 @@
 
-{% url 'components_data_view' content_type_id=content_type_id as base_url %}
+{% url 'components_dataview' content_type_id=content_type_id as base_url %}
 <div
 	hx-get="{{ base_url }}{% if filters %}{% for key, value in filters.items %}{% if forloop.first %}?{% else %}&{% endif %}{{ key|urlencode }}={{ value|urlencode }}{% endfor %}{% endif %}{% if component_id %}{% if filters %}&{% else %}?{% endif %}_component_id={{ component_id }}{% endif %}{% if args %}{% for key, value in args.items %}{% if filters or component_id or not forloop.first %}&{% else %}?{% endif %}_arg_{{ key|urlencode }}={{ value|urlencode }}{% endfor %}{% endif %}{% if request.GET.urlencode %}{% if filters or component_id or args %}&{% else %}?{% endif %}{{ request.GET.urlencode }}{% endif %}"
 	hx-trigger="load"

--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/dataviews/display_options.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/dataviews/display_options.html
@@ -4,7 +4,7 @@
     bloomerp-component="dataview-display-options"
     data-content-type-id="{{ content_type_id }}"
     data-preference-id="{{ preference.id }}"
-    data-preference-url="{% url 'components_change_data_view_preference' content_type_id=content_type_id %}"
+    data-preference-url="{% url 'components_update_dataview_preference' content_type_id=content_type_id %}"
     data-view-type="{{ preference.view_type }}"
     data-split-view-enabled="{{ preference.split_view_enabled }}"
     class="max-h-[60vh] overflow-y-auto"

--- a/bloomerp/django_bloomerp/bloomerp/templates/views/generic/model/bloomerp_list.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/views/generic/model/bloomerp_list.html
@@ -1,5 +1,5 @@
 <div
-	hx-get="{% url 'components_data_view' content_type_id=content_type_id %}{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}"
+	hx-get="{% url 'components_dataview' content_type_id=content_type_id %}{% if request.GET.urlencode %}?{{ request.GET.urlencode }}{% endif %}"
 	hx-headers='{"X-Bloomerp-Sync-Url": "true"}'
 	hx-trigger="load"
 	hx-target="this"

--- a/bloomerp/django_bloomerp/bloomerp/tests/components/dataview.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/components/dataview.py
@@ -733,7 +733,7 @@ class TestDataView(BaseBloomerpModelTestCase):
         )
 
         url = reverse(
-            viewname="components_change_data_view_preference",
+            viewname="components_update_dataview_preference",
             kwargs={"content_type_id": content_type.id},
         )
 

--- a/bloomerp/django_bloomerp/bloomerp/tests/components/dataview.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/components/dataview.py
@@ -76,7 +76,7 @@ class TestDataView(BaseBloomerpModelTestCase):
         # 4. Make sure the initial dataview load preserves the current query string
         content_type_id = ContentType.objects.get_for_model(self.CustomerModel).id
         dataview_url = reverse(
-            viewname="components_data_view",
+            viewname="components_dataview",
             kwargs={"content_type_id": content_type_id},
         )
 
@@ -87,7 +87,7 @@ class TestDataView(BaseBloomerpModelTestCase):
 
         content_type_id = ContentType.objects.get_for_model(self.CustomerModel).id
         url = reverse(
-            viewname="components_data_view",
+            viewname="components_dataview",
             kwargs={"content_type_id": content_type_id},
         ) + "?first_name=xyz&q=alice&page=3"
 
@@ -133,7 +133,7 @@ class TestDataView(BaseBloomerpModelTestCase):
         # 4. Make sure the page bootstraps the dataview with the filter query string
         content_type_id = ContentType.objects.get_for_model(self.CustomerModel).id
         dataview_url = reverse(
-            viewname="components_data_view",
+            viewname="components_dataview",
             kwargs={"content_type_id": content_type_id},
         )
 
@@ -224,7 +224,7 @@ class TestDataView(BaseBloomerpModelTestCase):
         self.client.force_login(self.normal_user)
         
         url = reverse(
-            viewname="components_data_view",
+            viewname="components_dataview",
             kwargs={"content_type_id": content_type.id},
         )
         response = self.client.get(url, HTTP_HX_REQUEST="true")
@@ -233,8 +233,8 @@ class TestDataView(BaseBloomerpModelTestCase):
         self.assertContains(response, "First Name", html=False)
         self.assertNotContains(response, "<th >Last Name</th>", html=False)
 
-        data_view_fields = get_data_view_fields(preference, "table")
-        self.assertEqual([field.id for field in data_view_fields.visible_fields], [first_name_field.id])
+        dataview_fields = get_data_view_fields(preference, "table")
+        self.assertEqual([field.id for field in dataview_fields.visible_fields], [first_name_field.id])
 
         preference.refresh_from_db()
         self.assertEqual(preference.get_visible_field_ids("table"), [first_name_field.id])
@@ -277,7 +277,7 @@ class TestDataView(BaseBloomerpModelTestCase):
         # Create url with filter for first_name
         content_type_id = ContentType.objects.get_for_model(self.CustomerModel).id
         url = reverse(
-            viewname="components_data_view",
+            viewname="components_dataview",
             kwargs={"content_type_id": content_type_id},
         ) + "?first_name=Alice"
         
@@ -298,7 +298,7 @@ class TestDataView(BaseBloomerpModelTestCase):
 
         content_type_id = ContentType.objects.get_for_model(self.CustomerModel).id
         url = reverse(
-            viewname="components_data_view",
+            viewname="components_dataview",
             kwargs={"content_type_id": content_type_id},
         ) + "?sort=first_name&direction=asc"
 
@@ -315,7 +315,7 @@ class TestDataView(BaseBloomerpModelTestCase):
 
         content_type_id = ContentType.objects.get_for_model(self.CustomerModel).id
         url = reverse(
-            viewname="components_data_view",
+            viewname="components_dataview",
             kwargs={"content_type_id": content_type_id},
         ) + "?first_name__icontains=a&q=a&page=3&sort=first_name&direction=asc"
 
@@ -323,7 +323,7 @@ class TestDataView(BaseBloomerpModelTestCase):
         self.assertEqual(response.status_code, 200)
 
         dataview_url = reverse(
-            viewname="components_data_view",
+            viewname="components_dataview",
             kwargs={"content_type_id": content_type_id},
         )
         content = response.content.decode()
@@ -364,7 +364,7 @@ class TestDataView(BaseBloomerpModelTestCase):
             self.create_customer(f"Batch-{index}", "Kanban", 123)
 
         dataview_url = reverse(
-            viewname="components_data_view",
+            viewname="components_dataview",
             kwargs={"content_type_id": content_type.id},
         )
 
@@ -377,7 +377,7 @@ class TestDataView(BaseBloomerpModelTestCase):
         self.assertNotContains(response, 'data-testid="data-view-pagination"', html=False)
 
         column_url = reverse(
-            viewname="components_data_view_action",
+            viewname="components_dataview_action",
             kwargs={"content_type_id": content_type.id, "action": "column"},
         )
         page_response = self.client.get(
@@ -419,7 +419,7 @@ class TestDataView(BaseBloomerpModelTestCase):
 
         # 2. Request the dataview component.
         url = reverse(
-            viewname="components_data_view",
+            viewname="components_dataview",
             kwargs={"content_type_id": content_type.id},
         )
         response = self.client.get(url, HTTP_HX_REQUEST="true")
@@ -465,7 +465,7 @@ class TestDataView(BaseBloomerpModelTestCase):
         for lookup in ["", "__exact"]:
             content_type_id = ContentType.objects.get_for_model(self.CustomerModel).id
             url = reverse(
-                viewname="components_data_view",
+                viewname="components_dataview",
                 kwargs={"content_type_id": content_type_id},
             ) + "?country" + lookup + "=" + str(country.id)
 
@@ -501,7 +501,7 @@ class TestDataView(BaseBloomerpModelTestCase):
         for lookup in ["__name", "__name__exact"]:
             content_type_id = ContentType.objects.get_for_model(self.CustomerModel).id
             url = reverse(
-                viewname="components_data_view",
+                viewname="components_dataview",
                 kwargs={"content_type_id": content_type_id},
             ) + "?country" + lookup + "=" + country.name
 
@@ -534,7 +534,7 @@ class TestDataView(BaseBloomerpModelTestCase):
         # Create url with filter for first_name and last_name
         content_type_id = ContentType.objects.get_for_model(self.CustomerModel).id
         url = reverse(
-            viewname="components_data_view",
+            viewname="components_dataview",
             kwargs={"content_type_id": content_type_id},
         ) + "?q=Alice Johnson"
         

--- a/bloomerp/django_bloomerp/bloomerp/tests/components/test_pivot_dataview.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/components/test_pivot_dataview.py
@@ -70,7 +70,7 @@ class TestPivotDataView(BaseBloomerpModelTestCase):
 
     def _component_url(self) -> str:
         return reverse(
-            "components_data_view",
+            "components_dataview",
             kwargs={"content_type_id": self._field("region").content_type_id},
         )
 

--- a/bloomerp/django_bloomerp/bloomerp/tests/components/test_pivot_dataview.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/components/test_pivot_dataview.py
@@ -254,7 +254,7 @@ class TestPivotDataView(BaseBloomerpModelTestCase):
 
         # 4. Submit ordered row and column selections through the preference endpoint.
         preference_url = reverse(
-            "components_change_data_view_preference",
+            "components_update_dataview_preference",
             kwargs={"content_type_id": self._field("region").content_type_id},
         )
         post_response = self.client.post(

--- a/bloomerp/django_bloomerp/bloomerp/tests/e2e/test_dataview_e2e.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/e2e/test_dataview_e2e.py
@@ -9,7 +9,7 @@ from playwright.sync_api import Locator, Page, expect
 
 from bloomerp.management.commands import save_application_fields
 from bloomerp.models import ApplicationField
-from bloomerp.models.users.user_list_view_preference import UserListViewPreference, ViewTypeEnum
+from bloomerp.models.users.user_list_view_preference import UserListViewPreference, DataviewType
 from bloomerp.tests.base import BaseBloomerpModelTestCase
 from bloomerp.tests.utils.dynamic_models import create_test_models
 from bloomerp.utils.models import get_list_view_url
@@ -105,7 +105,7 @@ def _apply_first_name_filter(page: Page, value: str, response_timeout: int = 300
     value_input.fill(value)
 
     with page.expect_response(
-        lambda response: "components/data_view" in response.url,
+        lambda response: "components/dataview" in response.url,
         timeout=response_timeout,
     ):
         page.locator("#apply-filters-button").click()
@@ -127,7 +127,7 @@ def apply_filter(page: Page, filter_key: str, filter_value: str, response_timeou
     value_input.fill(filter_value)
 
     with page.expect_response(
-        lambda response: "components/data_view" in response.url,
+        lambda response: "components/dataview" in response.url,
         timeout=response_timeout,
     ):
         page.locator("#apply-filters-button").click()
@@ -165,7 +165,7 @@ def search(
     search_input.click()
 
     with page.expect_response(
-        lambda response: "components/data_view" in response.url and f"q={query}" in response.url,
+        lambda response: "components/dataview" in response.url and f"q={query}" in response.url,
         timeout=response_timeout,
     ):
         page.keyboard.type(query, delay=20)
@@ -177,7 +177,7 @@ def search(
     )
 
 
-def change_view_type(view_type:ViewTypeEnum, page: Page) -> None:
+def change_view_type(view_type:DataviewType, page: Page) -> None:
     page.get_by_role("button", name="Display").click()
     display_menu = page.locator("div[role='menu']:visible").filter(
         has=page.locator(f"button[data-display-options-values*='\"view_type\": \"{view_type.value.key}\"']")
@@ -316,7 +316,7 @@ class TestDataViewE2E:
         page = authenticated_dataview_page
 
         # 1. Switch to the pivot view and locate its native row-field selector.
-        change_view_type(ViewTypeEnum.PIVOT_TABLE, page)
+        change_view_type(DataviewType.PIVOT_TABLE, page)
         display_menu = page.locator("div[role='menu']:visible").filter(
             has=page.locator("select[name='row_field_ids']")
         )

--- a/bloomerp/django_bloomerp/bloomerp/tests/workspaces/test_tile_rendering.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/workspaces/test_tile_rendering.py
@@ -1,17 +1,28 @@
 from bs4 import BeautifulSoup
+from django import forms
+from django.contrib.contenttypes.models import ContentType
 from django.template.loader import render_to_string
 from django.test import RequestFactory
+from django.http import HttpResponse
+from django.urls import reverse
+from unittest.mock import patch
 
+from bloomerp.models.users.user_list_view_preference import UserListViewPreference
 from bloomerp.models.workspaces.tile import Tile
 from bloomerp.services.permission_services import UserPermissionManager
 from bloomerp.services.workspace_services import render_tile_to_string
 from bloomerp.tests.base import BaseBloomerpModelTestCase
 from bloomerp.workspaces.links_tile.model import Link, LinkTileConfig
 from bloomerp.workspaces.links_tile.render import LinksTileRenderer
+from bloomerp.workspaces.dataview_tile.form import DataViewTileForm
+from bloomerp.workspaces.dataview_tile.model import DataViewTileConfig
+from bloomerp.workspaces.dataview_tile.render import DataViewTileRenderer
 from bloomerp.workspaces.text_tile.model import TextTileConfig
 from bloomerp.workspaces.text_tile.render import render_html
 from bloomerp.workspaces.tiles import TileType
 from bloomerp.workspaces.utils import UserParameterResolver
+from bloomerp.widgets.foreign_field_widget import ForeignFieldWidget
+from bloomerp.views.workspaces.create_tile import CREATE_TILE_SESSION_KEY
 
 
 class WorkspaceTileRenderingTests(BaseBloomerpModelTestCase):
@@ -44,6 +55,142 @@ class WorkspaceTileRenderingTests(BaseBloomerpModelTestCase):
         # 3. Verify the template content renders instead of the template file name.
         self.assertIn("Visible workspace tile", html)
         self.assertNotIn("cotton/workspaces/tiles/text.html", html)
+
+    def test_data_view_tile_is_registered_with_its_builder_and_renderer(self):
+        """
+        Use case: A user opens the workspace tile type selector.
+        Expected result: Data View is an available tile backed by its form, config, and renderer.
+        """
+        # 1. Resolve the registered data-view tile definition.
+        definition = TileType.DATAVIEW_TILE.value
+
+        # 2. Verify every runtime dependency is registered.
+        self.assertIs(definition.form_cls, DataViewTileForm)
+        self.assertIs(definition.model, DataViewTileConfig)
+        self.assertIs(definition.render_cls, DataViewTileRenderer)
+
+    def test_data_view_tile_form_uses_requested_widgets_and_nullable_preference(self):
+        """
+        Use case: A user configures a data-view tile for a permitted model.
+        Expected result: The model uses ForeignFieldWidget and the optional preference uses a normal select.
+        """
+        # 1. Create a saved preference for a model the admin user may view.
+        content_type = ContentType.objects.get_for_model(self.CustomerModel)
+        preference = UserListViewPreference.objects.create(
+            user=self.admin_user,
+            content_type=content_type,
+            name="Workspace customers",
+        )
+
+        # 2. Build the tile form for that content type.
+        form = DataViewTileForm(
+            user=self.admin_user,
+            initial={"content_type_id": content_type.pk},
+        )
+
+        # 3. Verify the widget contracts and scoped preference choices.
+        self.assertIsInstance(form.fields["content_type_id"].widget, ForeignFieldWidget)
+        self.assertIsInstance(form.fields["list_view_preference_id"].widget, forms.Select)
+        self.assertNotIsInstance(
+            form.fields["list_view_preference_id"].widget,
+            ForeignFieldWidget,
+        )
+        self.assertFalse(form.fields["list_view_preference_id"].required)
+        self.assertIn(preference, form.fields["list_view_preference_id"].queryset)
+
+    def test_data_view_tile_form_saves_a_null_list_view_preference(self):
+        """
+        Use case: A user chooses a model but leaves the list-view preference empty.
+        Expected result: The tile config stores the content type and a null preference.
+        """
+        # 1. Submit the builder form without a preference.
+        content_type = ContentType.objects.get_for_model(self.CustomerModel)
+        form = DataViewTileForm(
+            data={
+                "content_type_id": content_type.pk,
+                "list_view_preference_id": "",
+            },
+            user=self.admin_user,
+        )
+
+        # 2. Apply the registered form operation to an empty config.
+        operation = DataViewTileConfig.get_operation("set_form")
+        response = operation.handler.handle(DataViewTileConfig.get_default(), form)
+
+        # 3. Verify the nullable value is persisted in the configuration.
+        self.assertEqual(response.config.content_type_id, content_type.pk)
+        self.assertIsNone(response.config.list_view_preference_id)
+
+    def test_data_view_tile_builder_persists_form_configuration(self):
+        """
+        Use case: A user changes the data-view tile builder form.
+        Expected result: The preview component validates and persists the form-backed config.
+        """
+        # 1. Start a data-view tile builder session and sign in.
+        content_type = ContentType.objects.get_for_model(self.CustomerModel)
+        self.client.force_login(self.admin_user)
+        session = self.client.session
+        session[CREATE_TILE_SESSION_KEY] = {
+            "tile_type": TileType.DATAVIEW_TILE.name,
+            "config": DataViewTileConfig.get_default().model_dump(),
+        }
+        session.save()
+
+        # 2. Submit the default builder form with no saved preference selected.
+        response = self.client.post(
+            reverse("preview_workspace_tile"),
+            data={
+                "operation": "set_form",
+                "content_type_id": content_type.pk,
+                "list_view_preference_id": "",
+            },
+        )
+
+        # 3. Verify the component accepted and persisted the nullable configuration.
+        self.assertEqual(response.status_code, 200)
+        config = self.client.session[CREATE_TILE_SESSION_KEY]["config"]
+        self.assertEqual(config["content_type_id"], content_type.pk)
+        self.assertIsNone(config["list_view_preference_id"])
+
+    @patch("bloomerp.workspaces.dataview_tile.render.data_view")
+    def test_data_view_tile_renderer_uses_configured_available_preference(self, data_view_mock):
+        """
+        Use case: A tile is configured with a saved list-view preference.
+        Expected result: Rendering uses that preference without selecting it globally for the user.
+        """
+        # 1. Create selected and tile-specific preferences for the same model.
+        content_type = ContentType.objects.get_for_model(self.CustomerModel)
+        selected = UserListViewPreference.objects.create(
+            user=self.admin_user,
+            content_type=content_type,
+            name="Current preference",
+            selected=True,
+        )
+        tile_preference = UserListViewPreference.objects.create(
+            user=self.admin_user,
+            content_type=content_type,
+            name="Tile preference",
+        )
+        request = self.factory.get("/")
+        request.user = self.admin_user
+        data_view_mock.return_value = HttpResponse("Rendered data view")
+
+        # 2. Render the tile with the non-selected preference.
+        html = DataViewTileRenderer.render(
+            DataViewTileConfig(
+                content_type_id=content_type.pk,
+                list_view_preference_id=tile_preference.pk,
+            ),
+            request,
+        )
+
+        # 3. Verify the configured preference was passed through and selection was unchanged.
+        self.assertEqual(html, "Rendered data view")
+        self.assertEqual(data_view_mock.call_args.kwargs["preference"], tile_preference)
+        selected.refresh_from_db()
+        tile_preference.refresh_from_db()
+        self.assertTrue(selected.selected)
+        self.assertFalse(tile_preference.selected)
 
     def test_text_tile_renders_sanitized_editor_html(self):
         html = render_html('<h2>Notes</h2><p>Visible content</p><script>alert("xss")</script>')

--- a/bloomerp/django_bloomerp/bloomerp/tests/workspaces/test_tile_rendering.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/workspaces/test_tile_rendering.py
@@ -152,7 +152,7 @@ class WorkspaceTileRenderingTests(BaseBloomerpModelTestCase):
         self.assertEqual(config["content_type_id"], content_type.pk)
         self.assertIsNone(config["list_view_preference_id"])
 
-    @patch("bloomerp.workspaces.dataview_tile.render.data_view")
+    @patch("bloomerp.workspaces.dataview_tile.render.dataview")
     def test_data_view_tile_renderer_uses_configured_available_preference(self, data_view_mock):
         """
         Use case: A tile is configured with a saved list-view preference.

--- a/bloomerp/django_bloomerp/bloomerp/workspaces/dataview_tile/form.py
+++ b/bloomerp/django_bloomerp/bloomerp/workspaces/dataview_tile/form.py
@@ -1,21 +1,54 @@
-from bloomerp.models.users.user_list_view_preference import ViewTypeEnum
-
-
 from django import forms
 from django.contrib.contenttypes.models import ContentType
-from django.forms import Form
 from django.utils.translation import gettext_lazy as _
 
+from bloomerp.models.users.user_list_view_preference import UserListViewPreference
+from bloomerp.models.users.user import AbstractBloomerpUser
+from bloomerp.services.permission_services import UserPermissionManager
+from bloomerp.services.preference_services import PreferenceManager
+from bloomerp.widgets.foreign_field_widget import ForeignFieldWidget
 
-class DataViewTileForm(Form):
-    content_type = forms.ModelChoiceField(
+
+class DataViewTileForm(forms.Form):
+    content_type_id = forms.ModelChoiceField(
         label=_("Model"),
-        queryset=ContentType.objects.all(),
+        queryset=ContentType.objects.none(),
         required=True,
+        widget=ForeignFieldWidget(
+            model=ContentType,
+            attrs={"class": "input w-full"},
+        ),
+    )
+    list_view_preference_id = forms.ModelChoiceField(
+        label=_("List view preference"),
+        queryset=UserListViewPreference.objects.none(),
+        required=False,
+        empty_label=_("Use current preference"),
+        widget=forms.Select(attrs={"class": "select w-full"}),
     )
 
-    view_type = forms.ChoiceField(
-        label=_("View Type"),
-        choices=ViewTypeEnum.choices(),
-        required=True,
-    )
+    def __init__(self, *args, user: AbstractBloomerpUser, **kwargs) -> None:
+        """Build content-type and saved-preference choices available to the user."""
+        super().__init__(*args, **kwargs)
+        self.fields["content_type_id"].queryset = UserPermissionManager(
+            user
+        ).get_accessible_content_types("view")
+
+        content_type_id = self.data.get("content_type_id") if self.is_bound else None
+        if not content_type_id:
+            content_type_id = self.initial.get("content_type_id")
+
+        try:
+            content_type_is_accessible = bool(content_type_id) and self.fields[
+                "content_type_id"
+            ].queryset.filter(pk=content_type_id).exists()
+        except (TypeError, ValueError):
+            content_type_is_accessible = False
+
+        if content_type_is_accessible:
+            self.fields["list_view_preference_id"].queryset = PreferenceManager(
+                user
+            ).get_available(
+                UserListViewPreference,
+                {"content_type_id": content_type_id},
+            )

--- a/bloomerp/django_bloomerp/bloomerp/workspaces/dataview_tile/model.py
+++ b/bloomerp/django_bloomerp/bloomerp/workspaces/dataview_tile/model.py
@@ -1,121 +1,56 @@
-from copy import deepcopy
 from typing import Self
 
 from django.utils.translation import gettext_lazy as _
-from pydantic import BaseModel, Field
 
-from bloomerp.models.users.user_list_view_preference import UserListViewPreference, ViewTypeEnum
-
-from bloomerp.workspaces.base import BaseTileConfig, TileOperationDefinition, TileOperationHandler, TileOperationHandlerRespone
+from bloomerp.workspaces.base import (
+    BaseTileConfig,
+    TileOperationDefinition,
+    TileOperationHandler,
+    TileOperationHandlerRespone,
+)
+from bloomerp.workspaces.dataview_tile.form import DataViewTileForm
 
 
 class DataViewTileConfig(BaseTileConfig):
-    content_type_id:int | None = None
-    view_type:str = ViewTypeEnum.TABLE.value.key
-    fields:list[int] = Field(default_factory=list)
-    opts:dict = Field(default_factory=dict)
+    content_type_id: int | None = None
+    list_view_preference_id: int | None = None
 
     @classmethod
     def get_default(cls, *args, **kwargs) -> Self:
         return cls(
             content_type_id=kwargs.get("content_type_id"),
-            view_type=kwargs.get("view_type") or ViewTypeEnum.TABLE.value.key,
-            fields=list(kwargs.get("fields") or []),
-            opts=dict(kwargs.get("opts") or {}),
+            list_view_preference_id=kwargs.get("list_view_preference_id"),
         )
 
     @classmethod
-    def get_operation(cls, operation: str):
+    def get_operation(cls, operation: str) -> TileOperationDefinition:
         return {
-            "set_content_type_id" : TileOperationDefinition(
-                SetContentTypeIdOperation,
-                SetContentTypeIdHandler,
-            ),
-            "set_view_type": TileOperationDefinition(
-                SetViewTypeOperation,
-                SetViewTypeHandler,
-            ),
-            "toggle_field": TileOperationDefinition(
-                ToggleFieldOperation,
-                ToggleFieldHandler,
+            "set_form": TileOperationDefinition(
+                DataViewTileForm,
+                SetDataViewHandler,
             ),
         }[operation]
 
 
-def build_preview_preference(
-    base_preference: UserListViewPreference,
-    config: DataViewTileConfig,
-) -> UserListViewPreference:
-    display_fields = deepcopy(base_preference.display_fields or {})
-    display_fields[config.view_type] = list(config.fields)
-
-    return UserListViewPreference(
-        user=base_preference.user,
-        content_type=base_preference.content_type,
-        view_type=config.view_type,
-        split_view_enabled=base_preference.split_view_enabled,
-        display_fields=display_fields,
-        options={config.view_type: dict(config.opts or {})},
-    )
-    
-class SetContentTypeIdOperation(BaseModel):
-    content_type_id:int
-
-class SetContentTypeIdHandler(TileOperationHandler):
+class SetDataViewHandler(TileOperationHandler):
     @staticmethod
-    def handle(config:DataViewTileConfig, data:SetContentTypeIdOperation):
-        config.content_type_id = data.content_type_id
-        config.view_type = ViewTypeEnum.TABLE.value.key
-        config.fields = []
-        config.opts = {}
-
-        return TileOperationHandlerRespone(
-            config,
-            _("Model updated"),
-        )
-
-
-class SetViewTypeOperation(BaseModel):
-    view_type:str
-
-
-class SetViewTypeHandler(TileOperationHandler):
-    @staticmethod
-    def handle(config: DataViewTileConfig, data: SetViewTypeOperation):
-        if data.view_type not in ViewTypeEnum.values():
+    def handle(
+        config: DataViewTileConfig,
+        data: DataViewTileForm,
+    ) -> TileOperationHandlerRespone:
+        if not data.is_valid():
             return TileOperationHandlerRespone(
                 config,
-                _("Invalid view type"),
-                "error",
+                _("Please correct the data view configuration."),
+                "warning",
             )
 
-        config.view_type = data.view_type
+        content_type = data.cleaned_data["content_type_id"]
+        preference = data.cleaned_data["list_view_preference_id"]
+        config.content_type_id = content_type.pk
+        config.list_view_preference_id = preference.pk if preference else None
 
         return TileOperationHandlerRespone(
             config,
-            _("View updated"),
-        )
-
-
-class ToggleFieldOperation(BaseModel):
-    field_id:int
-
-
-class ToggleFieldHandler(TileOperationHandler):
-    @staticmethod
-    def handle(config: DataViewTileConfig, data: ToggleFieldOperation):
-        field_ids = list(config.fields)
-
-        if data.field_id in field_ids:
-            field_ids.remove(data.field_id)
-            message = _("Field removed")
-        else:
-            field_ids.append(data.field_id)
-            message = _("Field added")
-
-        config.fields = field_ids
-
-        return TileOperationHandlerRespone(
-            config,
-            message,
+            _("Data view updated"),
         )

--- a/bloomerp/django_bloomerp/bloomerp/workspaces/dataview_tile/render.py
+++ b/bloomerp/django_bloomerp/bloomerp/workspaces/dataview_tile/render.py
@@ -1,41 +1,35 @@
 from django.http import HttpRequest
-from django.contrib.contenttypes.models import ContentType
 
 from bloomerp.components.objects.dataviews.dataview import data_view
-from bloomerp.models.users.user import User
+from bloomerp.models.users.user_list_view_preference import UserListViewPreference
+from bloomerp.services.preference_services import PreferenceManager
 from bloomerp.workspaces.base import BaseTileRenderer
-from bloomerp.workspaces.dataview_tile.model import DataViewTileConfig, build_preview_preference
+from bloomerp.workspaces.dataview_tile.model import DataViewTileConfig
+
 
 class DataViewTileRenderer(BaseTileRenderer):
-
     @classmethod
-    def render(cls, config: DataViewTileConfig, user:User, query_params) -> str:
-        """
-        Render the data view tile based on the provided configuration.
+    def render(cls, config: DataViewTileConfig, request: HttpRequest) -> str:
+        """Render a permission-aware data view from the tile configuration."""
+        if config.content_type_id is None:
+            return ""
 
-        Args:
-            config (DataViewTileConfig): The configuration for the data view tile.
-
-        Returns:
-            str: The rendered HTML for the data view tile.
-        """
-        content_type = ContentType.objects.filter(id=config.content_type_id).first()
-        
-
-        request = HttpRequest()
-        request.user = user
-        request.method = "GET"
-        if query_params is not None:
-            request.GET = query_params.copy()
-
+        preference = None
+        if config.list_view_preference_id is not None:
+            preference = (
+                PreferenceManager(request.user)
+                .get_available(
+                    UserListViewPreference,
+                    {"content_type_id": config.content_type_id},
+                )
+                .filter(pk=config.list_view_preference_id)
+                .first()
+            )
+            if preference is not None:
+                preference = preference.effective_preference
 
         return data_view(
-            request, 
+            request,
             content_type_id=config.content_type_id,
+            preference=preference,
         ).content.decode("utf-8")
-
-        
-
-
-
-        

--- a/bloomerp/django_bloomerp/bloomerp/workspaces/dataview_tile/render.py
+++ b/bloomerp/django_bloomerp/bloomerp/workspaces/dataview_tile/render.py
@@ -1,6 +1,6 @@
 from django.http import HttpRequest
 
-from bloomerp.components.objects.dataviews.dataview import data_view
+from bloomerp.components.objects.dataviews.dataview import dataview
 from bloomerp.models.users.user_list_view_preference import UserListViewPreference
 from bloomerp.services.preference_services import PreferenceManager
 from bloomerp.workspaces.base import BaseTileRenderer
@@ -28,7 +28,15 @@ class DataViewTileRenderer(BaseTileRenderer):
             if preference is not None:
                 preference = preference.effective_preference
 
-        return data_view(
+        get_params = request.GET.copy()
+        get_params.pop("tile_id")
+        get_params.pop("colspan")
+        get_params.pop("max_cols")
+        
+        request.GET = get_params
+        
+        
+        return dataview(
             request,
             content_type_id=config.content_type_id,
             preference=preference,

--- a/bloomerp/django_bloomerp/bloomerp/workspaces/tiles.py
+++ b/bloomerp/django_bloomerp/bloomerp/workspaces/tiles.py
@@ -1,13 +1,14 @@
 
-from django.http import HttpRequest
 from django.utils.translation import gettext_lazy as _
 from enum import Enum
 
-from bloomerp.models.forms import form
 from bloomerp.workspaces.analytics_tile.model import AnalyticsTileConfig
 from bloomerp.workspaces.analytics_tile.render import AnalyticsTileRenderer
 from bloomerp.workspaces.canvas_tile.model import CanvasTileConfig
 from bloomerp.workspaces.canvas_tile.render import CanvasTileRenderer
+from bloomerp.workspaces.dataview_tile.form import DataViewTileForm
+from bloomerp.workspaces.dataview_tile.model import DataViewTileConfig
+from bloomerp.workspaces.dataview_tile.render import DataViewTileRenderer
 from bloomerp.workspaces.form_tile.model import FormTileConfig, FormTileForm
 from bloomerp.workspaces.form_tile.render import FormTileRenderer
 from bloomerp.workspaces.links_tile.model import LinkTileConfig
@@ -51,14 +52,14 @@ class TileType(Enum):
         render_cls=TextTileRenderer
     )
 
-    # DATAVIEW_TILE = TileTypeDefinition(
-    #     name=str(_("Data View")),
-    #     description=str(_("Displays and manages records from a selected model in a structured view with filtering, sorting, and interaction capabilities.")),
-    #     icon="fa-table",
-    #     form_cls=DataViewTileForm,
-    #     model=DataViewTileConfig,
-    #     render_cls=DataViewTileRenderer
-    # )
+    DATAVIEW_TILE = TileTypeDefinition(
+        name=str(_("Data View")),
+        description=str(_("Displays and manages records from a selected model in a structured view with filtering, sorting, and interaction capabilities.")),
+        icon="fa-table",
+        form_cls=DataViewTileForm,
+        model=DataViewTileConfig,
+        render_cls=DataViewTileRenderer,
+    )
     
     FORM_TILE = TileTypeDefinition(
         name=str(_("Form")),


### PR DESCRIPTION
## To-do

`2b2a` — Add data view tile to tile types

The runner's actionable-list endpoint did not return this requested to-do, so the full backend UUID was unavailable. The supplied SDK-derived branch name was used.

## Summary

- register Data View as a workspace tile type
- configure it with a permission-scoped content type selector using `ForeignFieldWidget`
- provide a standard nullable select for the list view preference
- persist form-backed tile configuration through the preview builder
- render an available configured preference without changing the user's globally selected preference
- add focused registry, widget, nullable-config, builder integration, and rendering tests

## Validation

Passed:

- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache UV_CACHE_DIR=/tmp/bloomerp-uv-cache uv run python manage.py test bloomerp.tests.workspaces.test_tile_rendering` — 13 tests passed
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache UV_CACHE_DIR=/tmp/bloomerp-uv-cache uv run python manage.py check` — no issues
- Python compilation for all changed Python modules
- `git diff --check`

Repository baseline findings outside this to-do:

- `bloomerp.tests.components.dataview.TestDataView.test_list_view_with_init_filters_includes_filter_box` fails because the pre-existing applied-filter label is absent, although filtering succeeds; this feature does not change that label path
- `manage.py makemigrations --check --dry-run` reports existing 0042 Meta-options drift unrelated to these changes

## User impact

Users can now create data-view workspace tiles for models they may view and optionally pin the tile to an available saved list-view preference. Leaving the preference blank follows the user's current preference.