### PR TITLE
[BUG] Back-refresh not loading full page

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/config/settings.py
+++ b/bloomerp/django_bloomerp/bloomerp/config/settings.py
@@ -156,6 +156,7 @@ if _has_allauth():
     ]
 
 BLOOMERP_MIDDLEWARE = [
+    "bloomerp.middleware.HTMXVaryMiddleware",
     "bloomerp.middleware.HTMXPermissionDeniedMiddleware",
     "django_htmx.middleware.HtmxMiddleware",
     "django_browser_reload.middleware.BrowserReloadMiddleware",

--- a/bloomerp/django_bloomerp/bloomerp/middleware.py
+++ b/bloomerp/django_bloomerp/bloomerp/middleware.py
@@ -1,8 +1,30 @@
+from collections.abc import Callable
+from threading import current_thread
+
+from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest, HttpResponse
 from django.template.loader import render_to_string
-from django.core.exceptions import PermissionDenied
-from threading import current_thread
+from django.utils.cache import patch_vary_headers
 from django.utils.deprecation import MiddlewareMixin
+
+
+class HTMXVaryMiddleware:
+    """Keep full-page and HTMX response variants in separate cache entries."""
+
+    vary_headers = (
+        "HX-Request",
+        "HX-History-Restore-Request",
+        "HX-Target",
+    )
+
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]) -> None:
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        response = self.get_response(request)
+        patch_vary_headers(response, self.vary_headers)
+        return response
+
 
 class HTMXPermissionDeniedMiddleware:
     def __init__(self, get_response):

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/utils/animations.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/utils/animations.ts
@@ -9,6 +9,10 @@ function insertSkeleton(target: HTMLElement) {
     // Create skeleton element
     const skeleton = document.createElement('div');
     skeleton.className = 'skeleton-loader';
+    // The loader is transient UI, not a valid page snapshot. If this request
+    // pushes a URL, make HTMX fetch the outgoing page again rather than cache
+    // and later restore the skeleton as its history content.
+    skeleton.setAttribute('hx-history', 'false');
     skeleton.innerHTML = `
     <div class="w-full">
         <div class="skeleton-header"></div>

--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/workspaces/tiles/link.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/workspaces/tiles/link.html
@@ -1,5 +1,14 @@
 <div class="space-y-1 flex flex-col">
     {% for link in config.links %}
-        <a href="{{ link.url }}" class="text-blue-500 hover:underline">{{ link.name }}</a>
+        <a
+            href="{{ link.url }}"
+            {% if link.is_internal %}
+                hx-get="{{ link.url }}"
+                hx-target="#main-content"
+                hx-push-url="true"
+                hx-swap="innerHTML"
+            {% endif %}
+            class="text-blue-500 hover:underline"
+        >{{ link.name }}</a>
     {% endfor %}
 </div>

--- a/bloomerp/django_bloomerp/bloomerp/templates/snippets/head.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/snippets/head.html
@@ -3,6 +3,7 @@
 
 <meta charset="utf-8" />
 <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+<meta name="htmx-config" content='{"refreshOnHistoryMiss": true}' />
 
 <title>
     Bloomerp {% block title %}{% endblock title %}

--- a/bloomerp/django_bloomerp/bloomerp/tests/e2e/test_dataview_e2e.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/e2e/test_dataview_e2e.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from playwright.sync_api import Locator, Page, expect
 
 from bloomerp.management.commands import save_application_fields
-from bloomerp.models import ApplicationField
+from bloomerp.models import ApplicationField, Sidebar, SidebarItem
 from bloomerp.models.users.user_list_view_preference import UserListViewPreference, ViewTypeEnum
 from bloomerp.tests.base import BaseBloomerpModelTestCase
 from bloomerp.tests.utils.dynamic_models import create_test_models
@@ -593,4 +593,52 @@ class TestDataViewE2E:
         
         # 3. Assert that the bloomerp-component="dataview-container" is still visible
         expect(page.locator("[bloomerp-component='dataview-container']")).to_be_visible()
+
+    def test_mixed_htmx_and_href_history_restores_complete_pages(
+        self,
+        authenticated_dataview_page: Page,
+        dataview_admin,
+        dataview_model,
+        live_server_url: str,
+    ):
+        """
+        Use case: An HTMX sidebar navigation is followed by a normal href navigation and browser back actions.
+        Expected result: History never restores a loader or an HTMX fragment as the complete document.
+        """
+        page = authenticated_dataview_page
+        list_path = reverse(get_list_view_url(dataview_model))
+
+        # 1. Add an internal sidebar link so the first navigation uses HTMX and the global loader.
+        sidebar = Sidebar.objects.filter(user=dataview_admin, selected=True).first()
+        if sidebar is None:
+            sidebar = Sidebar.objects.create(user=dataview_admin, name="History", selected=True)
+        SidebarItem.create_link(sidebar, "History list", list_path)
+        page.goto(f"{live_server_url}/")
+
+        with page.expect_response(lambda response: response.url.endswith(list_path)):
+            page.get_by_role("link", name="History list").click()
+        expect(page.locator("[bloomerp-component='dataview-container']")).to_be_visible()
+
+        # 2. Follow a plain href, reproducing the mixed navigation sequence from link tiles.
+        page.locator("#main-content").evaluate(
+            """element => {
+                const link = document.createElement('a');
+                link.id = 'plain-home-link';
+                link.href = '/';
+                link.textContent = 'Plain home link';
+                element.appendChild(link);
+            }"""
+        )
+        page.get_by_role("link", name="Plain home link").click()
+        expect(page).to_have_url(f"{live_server_url}/")
+
+        # 3. Go back through both entries and verify the outgoing home snapshot was not the loader.
+        go_page_back(page, expected_selector="[bloomerp-component='dataview-container']")
+        go_page_back(page, expected_url=f"{live_server_url}/")
+        expect(page.locator(".skeleton-loader")).to_have_count(0)
+
+        # 4. Refresh the restored entry and verify a complete document is returned, not an HTMX fragment.
+        page.reload(wait_until="domcontentloaded")
+        expect(page.locator("html > body#bloomerpBody")).to_have_count(1)
+        expect(page.locator("#main-content #htmx-addendum")).to_be_visible()
     

--- a/bloomerp/django_bloomerp/bloomerp/tests/test_htmx_history.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/test_htmx_history.py
@@ -1,0 +1,46 @@
+from django.http import HttpRequest, HttpResponse
+from django.test import RequestFactory, SimpleTestCase
+
+from bloomerp.middleware import HTMXVaryMiddleware
+
+
+class HTMXVaryMiddlewareTests(SimpleTestCase):
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+
+    def test_response_varies_by_headers_that_change_htmx_rendering(self) -> None:
+        """
+        Use case: A URL is requested first by HTMX and later by normal browser navigation.
+        Expected result: Caches keep full-page, history-restore, and target-specific responses separate.
+        """
+        # 1. Pass a response through the global HTMX cache middleware.
+        middleware = HTMXVaryMiddleware(lambda request: HttpResponse("response"))
+        response = middleware(self.factory.get("/objects/"))
+
+        # 2. Verify every request header that changes the rendered response is declared.
+        vary_headers = {header.strip().lower() for header in response["Vary"].split(",")}
+        self.assertEqual(
+            vary_headers,
+            {"hx-request", "hx-history-restore-request", "hx-target"},
+        )
+
+    def test_response_preserves_existing_vary_headers(self) -> None:
+        """
+        Use case: Another middleware already varies a response by cookies.
+        Expected result: The HTMX cache headers are added without discarding the existing value.
+        """
+        # 1. Create a response that already has a Vary header.
+        def get_response(request: HttpRequest) -> HttpResponse:
+            response = HttpResponse("response")
+            response["Vary"] = "Cookie"
+            return response
+
+        # 2. Pass the response through the global HTMX cache middleware.
+        response = HTMXVaryMiddleware(get_response)(self.factory.get("/objects/"))
+
+        # 3. Verify the existing and HTMX-specific variants are all retained.
+        vary_headers = {header.strip().lower() for header in response["Vary"].split(",")}
+        self.assertEqual(
+            vary_headers,
+            {"cookie", "hx-request", "hx-history-restore-request", "hx-target"},
+        )

--- a/bloomerp/django_bloomerp/bloomerp/tests/workspaces/test_tile_rendering.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/workspaces/test_tile_rendering.py
@@ -79,6 +79,11 @@ class WorkspaceTileRenderingTests(BaseBloomerpModelTestCase):
         self.assertEqual(rendered, f"/employees/?user={self.normal_user.pk}")
 
     def test_link_tile_resolves_current_user_parameters(self):
+        """
+        Use case: A workspace link tile points to an internal Bloomerp URL.
+        Expected result: The tile renders an HTMX navigation link with resolved parameters.
+        """
+        # 1. Render a link tile whose URL contains a current-user template parameter.
         config = LinkTileConfig(
             links=[
                 Link(
@@ -91,10 +96,43 @@ class WorkspaceTileRenderingTests(BaseBloomerpModelTestCase):
         request = self.factory.get("/")
         request.user = self.admin_user
 
+        # 2. Render the tile.
         html = LinksTileRenderer.render(config, request)
 
+        # 3. Verify the original config is preserved and rendered links use HTMX navigation.
+        resolved_url = f"/employees/?user={self.admin_user.id}"
         self.assertIn(f'href="/employees/?user={self.admin_user.id}"', html)
+        self.assertIn(f'hx-get="{resolved_url}"', html)
+        self.assertIn('hx-target="#main-content"', html)
+        self.assertIn('hx-push-url="true"', html)
+        self.assertIn('hx-swap="innerHTML"', html)
         self.assertEqual(config.links[0].url, "/employees/?user={{ current_user.id }}")
+
+    def test_link_tile_leaves_external_links_as_regular_anchors(self):
+        """
+        Use case: A workspace link tile points to an external URL.
+        Expected result: The tile renders a regular anchor without HTMX navigation.
+        """
+        # 1. Render a link tile with an external URL.
+        config = LinkTileConfig(
+            links=[
+                Link(
+                    url="https://example.com/docs",
+                    name="Docs",
+                    is_internal=False,
+                )
+            ]
+        )
+        request = self.factory.get("/")
+        request.user = self.admin_user
+
+        # 2. Render the tile.
+        html = LinksTileRenderer.render(config, request)
+
+        # 3. Verify external navigation remains a normal browser link.
+        self.assertIn('href="https://example.com/docs"', html)
+        self.assertNotIn("hx-get=", html)
+        self.assertNotIn("hx-target=", html)
 
     def test_user_parameter_resolver_hides_model_object_without_view_permission(self):
         customer = self.CustomerModel.objects.create(


### PR DESCRIPTION
## To-do
- ID: `21d5487e-5ae7-45d6-8936-70de8ded6482`
- Title: `[BUG] Back-refresh not loading full page`

## Root cause
The same application URL can return a full document or an HTMX fragment, but responses did not declare the HTMX request headers in `Vary`. Browser/proxy caches could therefore reuse a fragment for a normal navigation. Separately, the animation utility replaced `#main-content` with a skeleton before HTMX saved the outgoing history entry, allowing that transient loader to become the cached page.

## Summary
- Add global `Vary: HX-Request, HX-History-Restore-Request, HX-Target` handling so caches keep full-page and HTMX variants separate.
- Configure HTMX to perform a real page reload on history cache misses.
- Exclude transient skeleton loaders from HTMX history snapshots.
- Keep the earlier ticket improvement that renders internal workspace link-tile links as HTMX navigation while leaving external links as normal anchors.
- Add middleware and Playwright regression coverage for HTMX navigation followed by a plain `href`, browser Back, and refresh.

## Impact
Mixed HTMX and ordinary navigation now restores a complete page across the application, rather than a loader or fragment-only document. Valid HTMX history entries remain fast; cache misses reload safely.

## Tests
- `.venv/bin/pytest bloomerp/tests/test_htmx_history.py bloomerp/tests/workspaces/test_tile_rendering.py -q` — 11 passed.
- `.venv/bin/pytest bloomerp/tests/e2e/test_dataview_e2e.py::TestDataViewE2E::test_mixed_htmx_and_href_history_restores_complete_pages -q` — 1 passed.
- `npm run build:js` — passed (TypeScript compilation and Vite production build).
- `.venv/bin/python manage.py check` — passed; existing third-party celery-beat model warnings only.

## Notes
The browser test emits existing warnings for dynamic model re-registration, PyPDF2 deprecation, ReportLab compatibility, and unordered test pagination.