### PR TITLE
Improve small screen layout controls

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/sidebar/Sidebar.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/sidebar/Sidebar.ts
@@ -161,15 +161,6 @@ export class Sidebar extends BaseComponent {
         this.floatingButton.classList.add('hidden');
     }
 
-    private toggleFloatingByTouch(): void {
-        if (!this.floatingButton) return;
-        if (this.floatingButton.classList.contains('hidden')) {
-            this.showFloating();
-        } else {
-            this.hideFloating();
-        }
-    }
-
 	private setupEventListeners(): void {
         // Close on overlay click
         if (this.overlayElement) {
@@ -236,8 +227,11 @@ export class Sidebar extends BaseComponent {
         this.handlePointer(event.clientX, event.clientY);
     };
 
-    private readonly onWindowTouchStart = (): void => {
-        this.toggleFloatingByTouch();
+    private readonly onWindowTouchStart = (event: TouchEvent): void => {
+        const touch = event.touches.item(0);
+        if (!touch) return;
+
+        this.handlePointer(touch.clientX, touch.clientY);
     };
 
     private readonly onDragStart = (event: DragEvent): void => {

--- a/bloomerp/django_bloomerp/bloomerp/templates/components/objects/dataview.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/components/objects/dataview.html
@@ -70,6 +70,8 @@
                         wrapper_class="w-full"
                         size="sm"
                         width="w-128"
+                        fixed=True
+                        menu_class="max-h-[calc(100vh-6rem)] max-w-[calc(100vw-1rem)] overflow-auto"
                         >
                         <div class="p-3">
                             <div>
@@ -92,7 +94,7 @@
             </div>
 
             <!--Add button-->
-            <div data-data-view-button="add">    
+            <div class="w-full sm:w-auto" data-data-view-button="add">
                 <c-ui.shortcut_tooltip 
                     position="bottom"
                     action="click"
@@ -113,12 +115,14 @@
             </div>
 
             <!--Bulk actions button-->
-            <div data-data-view-button="bulk-actions">
+            <div class="w-full sm:w-auto" data-data-view-button="bulk-actions">
                 <c-ui.shortcut_tooltip position="bottom" shortcut="mod+3">
                     <c-ui.dropdown.body 
                         trigger_text="Bulk Actions"
                         trigger_icon_class="fa fa-list-check"
                         trigger_button_class="btn-secondary"
+                        trigger_class="w-full justify-center gap-2"
+                        wrapper_class="w-full"
                         size="sm"
                         >
                         <c-ui.dropdown.item 
@@ -134,7 +138,7 @@
             </div>
 
             <!--Export button-->
-            <div data-data-view-button="export">
+            <div class="w-full sm:w-auto" data-data-view-button="export">
                 <c-ui.shortcut_tooltip 
                     position="bottom"  
                     shortcut="mod+4">
@@ -169,6 +173,8 @@
                         wrapper_class="w-full"
                         size="sm"
                         width="w-80"
+                        fixed=True
+                        menu_class="max-h-[calc(100vh-6rem)] max-w-[calc(100vw-1rem)] overflow-auto"
                         >
                     
                     <div class="p-2" id="data-table-display-options-{{ content_type_id }}">
@@ -188,7 +194,7 @@
             {% endif %}
             
             <!--Select-->
-            <div data-data-view-button="select-preference">
+            <div class="w-full sm:w-auto" data-data-view-button="select-preference">
                 <c-ui.shortcut_tooltip position="bottom" shortcut="mod+6">
                     <c-features.preferences.select_preference_button
                         model="UserListViewPreference"

--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/preferences/select_preference_button.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/preferences/select_preference_button.html
@@ -7,6 +7,8 @@
     position="right"
     size="sm"
     width="w-80"
+    fixed=True
+    menu_class="max-h-[calc(100vh-6rem)] max-w-[calc(100vw-1rem)] overflow-auto"
 >
     <div
         id="select-preference-dropdown-{{ model }}"

--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/sectioned_layouts/container.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/sectioned_layouts/container.html
@@ -1,5 +1,42 @@
 {% load bloomerp %}
 
+<style>
+    @media (max-width: 640px) {
+        [bloomerp-component="{{ component_name }}"] [data-layout-grid] {
+            grid-template-columns: minmax(0, 1fr) !important;
+        }
+
+        [bloomerp-component="{{ component_name }}"] [data-layout-grid] > [data-layout-item-id] {
+            grid-column: span 1 / span 1 !important;
+        }
+
+        [bloomerp-component="{{ component_name }}"] [data-layout-action-group] > *,
+        [bloomerp-component="{{ component_name }}"] [data-layout-action-group] button {
+            min-width: 0;
+        }
+
+        [bloomerp-component="{{ component_name }}"] .workspace-row__header,
+        [bloomerp-component="{{ component_name }}"] .workspace-row__controls {
+            flex-wrap: wrap;
+        }
+
+        [bloomerp-component="{{ component_name }}"] .workspace-row__controls {
+            width: 100%;
+        }
+
+        [bloomerp-component="{{ component_name }}"] .workspace-row__controls [data-row-title-input] {
+            min-width: 0;
+            flex: 1 1 10rem;
+        }
+
+        [bloomerp-component="{{ component_name }}"] .bloomerp-dropdown-menu {
+            max-width: calc(100vw - 1rem);
+            max-height: calc(100vh - 6rem);
+            overflow: auto;
+        }
+    }
+</style>
+
 <div
     bloomerp-component="{{ component_name }}"
     data-layout="{{ layout | dump_layout_json }}"

--- a/bloomerp/django_bloomerp/bloomerp/tests/e2e/test_sidebar_e2e.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/e2e/test_sidebar_e2e.py
@@ -1,0 +1,49 @@
+from playwright.sync_api import Browser, expect
+
+
+def test_regular_phone_tap_does_not_reveal_sidebar_button(
+    browser: Browser,
+    live_server_url: str,
+    test_user,
+) -> None:
+    """
+    Use case: A user taps a normal page control on a phone while the sidebar is closed.
+    Expected result: The control handles the tap and the floating sidebar button stays hidden.
+    """
+    # 1. Open an authenticated phone-sized page with touch support.
+    test_user.is_staff = True
+    test_user.save(update_fields=["is_staff"])
+    context = browser.new_context(
+        viewport={"width": 390, "height": 844},
+        has_touch=True,
+        is_mobile=True,
+    )
+    page = context.new_page()
+    page.goto(f"{live_server_url}/login/")
+    page.locator('input[name="username"]').fill("testuser")
+    page.locator('input[name="password"]').fill("testpass123")
+    page.get_by_role("button", name="Login").tap()
+    page.wait_for_url(f"{live_server_url}/")
+
+    # 2. Add and tap a regular control away from the sidebar activation corner.
+    page.evaluate(
+        """
+        () => {
+            const button = document.createElement('button');
+            button.textContent = 'Phone action';
+            button.style.position = 'fixed';
+            button.style.left = '160px';
+            button.style.top = '300px';
+            button.addEventListener('click', () => button.dataset.clicked = 'true');
+            document.body.appendChild(button);
+        }
+        """
+    )
+    action_button = page.get_by_role("button", name="Phone action")
+    action_button.tap()
+
+    # 3. Confirm the intended click ran without revealing the floating sidebar control.
+    expect(action_button).to_have_attribute("data-clicked", "true")
+    expect(page.locator("#sidebar-toggle-floating")).to_be_hidden()
+
+    context.close()


### PR DESCRIPTION
## Todo
- ID: 5c15567e-bb5f-4731-ae67-e874e54dee94
- Title: Small screen html adjustments necessary

## Summary
- Constrain dataview Filter, Display, and preference dropdown menus to the phone viewport using fixed placement and scroll limits.
- Normalize dataview action wrappers so Add, Bulk Actions, Export, Display, and preference controls are all full-width on phone screens and auto-width from `sm` upward.
- Collapse sectioned layout grids to one column on phone screens and allow layout action/row controls to wrap instead of overflowing.
- Restrict the floating sidebar touch activation to the existing top-left activation zone so regular phone taps reach their intended controls.

## Testing
- Passed: `npm run type-check`
- Passed: `npm run build`
- Passed: `UV_CACHE_DIR=/private/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run pytest bloomerp/tests/e2e/test_sidebar_e2e.py -q`
- Passed: `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py check`
- Passed: `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python -m py_compile bloomerp/templatetags/bloomerp.py`
- Passed: `git diff --check`

## Notes
- The focused Playwright test uses an authenticated, phone-sized Chromium context with touch support and verifies that a normal tap triggers its target without revealing the floating sidebar button.
