### PR TITLE
Add pagination and search to accessible tables endpoint

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/inputs/SqlQueryEditor.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/inputs/SqlQueryEditor.ts
@@ -23,6 +23,7 @@ interface SqlDatabase {
 
 interface SqlSchemaResponse {
     databases: SqlDatabase[];
+    total_pages?: number;
 }
 
 interface SavedSqlQuery {
@@ -453,22 +454,42 @@ export default class SqlQueryEditor extends BaseComponent {
         if (refresh) {
             params.set('refresh', 'true');
         }
-
-        const endpoint = `${this.schemaUrl}?${params.toString()}`;
+        params.set('page_size', '100');
 
         try {
             insertSkeleton(this.catalogTree);
+            const databases = new Map<string, SqlDatabase>();
+            let page = 1;
+            let totalPages = 1;
 
-            const response = await fetch(endpoint, {
-                credentials: 'same-origin',
-            });
+            do {
+                params.set('page', String(page));
+                const endpoint = `${this.schemaUrl}?${params.toString()}`;
+                const response = await fetch(endpoint, {
+                    credentials: 'same-origin',
+                });
 
-            if (!response.ok) {
-                throw new Error(`Failed to fetch schema: ${response.status}`);
-            }
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch schema: ${response.status}`);
+                }
 
-            const payload = await response.json() as SqlSchemaResponse;
-            this.schemaData = payload.databases || [];
+                const payload = await response.json() as SqlSchemaResponse;
+                payload.databases?.forEach((database) => {
+                    const existing = databases.get(database.name);
+                    if (existing) {
+                        existing.tables.push(...database.tables);
+                    } else {
+                        databases.set(database.name, {
+                            ...database,
+                            tables: [...database.tables],
+                        });
+                    }
+                });
+                totalPages = Math.max(1, payload.total_pages || 1);
+                page += 1;
+            } while (page <= totalPages);
+
+            this.schemaData = Array.from(databases.values());
             this.renderCatalog(searchValue.toLowerCase());
             this.refreshAutocompleteTokens();
             this.setupSchemaCompleter();

--- a/bloomerp/django_bloomerp/bloomerp/tests/api/test_sql_execute.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/api/test_sql_execute.py
@@ -1,5 +1,8 @@
+from unittest.mock import patch
+
 from django.contrib.auth.models import Permission
 
+from bloomerp.services.sql_services import DatabaseTable, Field
 from bloomerp.tests.base import BaseBloomerpModelTestCase
 
 
@@ -60,6 +63,90 @@ class SqlExecuteApiTests(BaseBloomerpModelTestCase):
         ]
         self.assertTrue(fields)
         self.assertTrue(all("icon" not in field for field in fields))
+
+    @patch("bloomerp.views.api.sql.accessible_tables.SqlExecutor.get_accessible_tables_and_fields")
+    def test_accessible_tables_api_supports_search_and_pagination(self, get_tables):
+        """
+        Use case: A user searches accessible table metadata and requests a specific page.
+        Expected result: Search is applied before pagination and pagination metadata is returned.
+        """
+        # 1. Provide predictable accessible tables and authenticate the user.
+        get_tables.return_value = [
+            DatabaseTable(
+                name="suppliers",
+                fields=[Field(name="email", field_type="text")],
+            ),
+            DatabaseTable(
+                name="customers",
+                fields=[Field(name="email", field_type="text")],
+            ),
+            DatabaseTable(
+                name="invoices",
+                fields=[Field(name="customer_id", field_type="integer")],
+            ),
+        ]
+        self.client.force_login(self.admin_user)
+
+        # 2. Search by field name and request the second matching table.
+        response = self.client.get(
+            "/api/sql/accessible-tables/?search=email&page=2&page_size=1&refresh=true"
+        )
+
+        # 3. Verify filtered pagination data and the existing database response shape.
+        self.assertEqual(response.status_code, 200)
+        payload = response.json()
+        self.assertEqual(
+            [table["name"] for table in payload["databases"][0]["tables"]],
+            ["suppliers"],
+        )
+        self.assertEqual(payload["page"], 2)
+        self.assertEqual(payload["page_size"], 1)
+        self.assertEqual(payload["total_tables"], 2)
+        self.assertEqual(payload["total_pages"], 2)
+        self.assertFalse(payload["has_next"])
+        self.assertTrue(payload["has_previous"])
+        self.assertTrue(payload["refreshed"])
+
+    @patch("bloomerp.views.api.sql.accessible_tables.SqlExecutor.get_accessible_tables_and_fields")
+    def test_accessible_tables_api_searches_field_types(self, get_tables):
+        """
+        Use case: A user searches accessible metadata by a field type.
+        Expected result: Only matching fields and their parent tables are returned.
+        """
+        # 1. Provide a table containing text and integer fields and authenticate the user.
+        get_tables.return_value = [
+            DatabaseTable(
+                name="customers",
+                fields=[
+                    Field(name="email", field_type="text"),
+                    Field(name="age", field_type="integer"),
+                ],
+            )
+        ]
+        self.client.force_login(self.admin_user)
+
+        # 2. Search using the integer field type.
+        response = self.client.get("/api/sql/accessible-tables/?search=INTEGER")
+
+        # 3. Verify the table remains but non-matching fields are excluded.
+        self.assertEqual(response.status_code, 200)
+        tables = response.json()["databases"][0]["tables"]
+        self.assertEqual([field["name"] for field in tables[0]["fields"]], ["age"])
+
+    def test_accessible_tables_api_rejects_invalid_pagination(self):
+        """
+        Use case: A user requests an invalid accessible-tables page size.
+        Expected result: The API responds with a validation error.
+        """
+        # 1. Authenticate a user allowed to inspect accessible tables.
+        self.client.force_login(self.admin_user)
+
+        # 2. Request a page size above the documented maximum.
+        response = self.client.get("/api/sql/accessible-tables/?page_size=101")
+
+        # 3. Verify query validation rejects the request.
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("page_size", response.json())
 
     def test_execute_sql_api_requires_permission(self):
         """

--- a/bloomerp/django_bloomerp/bloomerp/views/api/sql/accessible_tables.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/api/sql/accessible_tables.py
@@ -1,36 +1,101 @@
-from django.contrib.auth.decorators import login_required
-from django.http import HttpRequest, JsonResponse
+from django.http import HttpRequest
 
 from bloomerp.router import router
 from bloomerp.services.sql_services import DatabaseTable, SqlExecutor
-
 from bloomerp.views.api.base import BaseBloomerpApiView
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers
+from rest_framework.response import Response
+
+
+class AccessibleTablesQuerySerializer(serializers.Serializer):
+    page = serializers.IntegerField(required=False, min_value=1, default=1)
+    page_size = serializers.IntegerField(
+        required=False,
+        min_value=1,
+        max_value=100,
+        default=25,
+    )
+    search = serializers.CharField(required=False, allow_blank=True, max_length=100)
+    refresh = serializers.BooleanField(required=False, default=False)
+
+    def validate_search(self, value: str) -> str:
+        """Normalize table and field search terms."""
+        return value.strip().lower()
+
+
+class AccessibleTablesResponseSerializer(serializers.Serializer):
+    databases = serializers.ListField(child=serializers.DictField())
+    refreshed = serializers.BooleanField()
+    page = serializers.IntegerField()
+    page_size = serializers.IntegerField()
+    total_tables = serializers.IntegerField()
+    total_pages = serializers.IntegerField()
+    has_next = serializers.BooleanField()
+    has_previous = serializers.BooleanField()
+
 
 @router.register(
-    path="api/sql/accessible-tables/", 
-    name="api_sql_accessible_tables"
-    )
+    path="api/sql/accessible-tables/",
+    name="api_sql_accessible_tables",
+)
 class AccessibleTablesView(BaseBloomerpApiView):
-    def get(self, request: HttpRequest) -> JsonResponse:
-        search = request.GET.get("search", "").strip().lower()
-        refresh = request.GET.get("refresh", "false").lower() == "true"
+    serializer_class = AccessibleTablesQuerySerializer
+    http_method_names = ["get", "options"]
+
+    @extend_schema(
+        parameters=[AccessibleTablesQuerySerializer],
+        responses={200: AccessibleTablesResponseSerializer},
+        description=(
+            "List SQL tables and fields available to the authenticated user. "
+            "Results can be searched by table name, field name, or field type and "
+            "are paginated after access policies and search filters are applied."
+        ),
+    )
+    def get(self, request: HttpRequest, *args, **kwargs) -> Response:
+        serializer = self.get_serializer(data=request.query_params)
+        serializer.is_valid(raise_exception=True)
+
+        page = serializer.validated_data["page"]
+        page_size = serializer.validated_data["page_size"]
+        search = serializer.validated_data.get("search", "")
+        refresh = serializer.validated_data["refresh"]
 
         executor = SqlExecutor(request.user)
-        tables = executor.get_accessible_tables_and_fields()
+        tables = sorted(
+            executor.get_accessible_tables_and_fields(),
+            key=lambda table: table.name.lower(),
+        )
 
         if search:
             tables = _filter_tables_by_search(tables, search)
+
+        total_tables = len(tables)
+        total_pages = (total_tables + page_size - 1) // page_size
+        page_start = (page - 1) * page_size
+        page_tables = tables[page_start : page_start + page_size]
 
         response = {
             "databases": [
                 {
                     "name": "bloomerp",
-                    "tables": [table.model_dump(include_field_icons=False) for table in tables],
+                    "tables": [
+                        table.model_dump(include_field_icons=False) for table in page_tables
+                    ],
                 }
             ],
             "refreshed": refresh,
+            "page": page,
+            "page_size": page_size,
+            "total_tables": total_tables,
+            "total_pages": total_pages,
+            "has_next": page < total_pages,
+            "has_previous": page > 1 and total_tables > 0,
         }
-        return JsonResponse(response)
+        return Response(response)
+
+    def get_serializer(self, *args, **kwargs):
+        return self.serializer_class(*args, **kwargs)
 
 
 def _filter_tables_by_search(tables: list[DatabaseTable], search: str) -> list[DatabaseTable]:

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.12.0beta8"
+version = "1.12.0beta9"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.12.0beta7"
+version = "1.12.0beta8"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## To-do

- Identifier: `5bba` (last four UUID characters from the supplied SDK branch name; the full backend ID was unavailable because `BLOOMERP_TODO_API_KEY` is not configured)
- Title: Add pagination and search capabilities to accessible tables endpoint

## Summary

- validate and document `page`, `page_size`, `search`, and `refresh` query parameters
- apply case-insensitive table/field search before stable pagination
- return pagination metadata while preserving the existing `databases` response shape
- make the SQL editor retrieve every schema page so catalog and autocomplete remain complete
- add focused coverage for search, pagination, field-type filtering, and invalid page sizes

## Tests

- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache-5bba PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.api.test_sql_execute.SqlExecuteApiTests.test_accessible_tables_api_omits_field_icons bloomerp.tests.api.test_sql_execute.SqlExecuteApiTests.test_accessible_tables_api_supports_search_and_pagination bloomerp.tests.api.test_sql_execute.SqlExecuteApiTests.test_accessible_tables_api_searches_field_types bloomerp.tests.api.test_sql_execute.SqlExecuteApiTests.test_accessible_tables_api_rejects_invalid_pagination` — passed (4 tests)
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache-5bba PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py check` — passed
- `npm run type-check` — passed
- Python compile checks and `git diff --check` — passed

## Notes

The full `SqlExecuteApiTests` class was also run. The new tests passed, but the existing `test_execute_sql_api_requires_permission` assertion failed because the endpoint returned `You do not have access to table: bloomerp_customer` instead of the expected `Permission denied`. This is outside this to-do and was not changed.

The backend to-do could not be assigned or moved to `in_review` because `BLOOMERP_TODO_API_KEY` is unavailable in this runtime.