### PR TITLE
Fix content object fields in user list view preferences

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/dataview.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/dataview.py
@@ -182,7 +182,10 @@ def _select_related_rendered_relations(
         except FieldDoesNotExist:
             continue
 
-        if model_field.many_to_one or model_field.one_to_one:
+        if (
+            getattr(model_field, "concrete", False)
+            and (model_field.many_to_one or model_field.one_to_one)
+        ):
             relation_names.append(model_field.name)
 
     if not relation_names:
@@ -458,4 +461,3 @@ def dataview_action(request: HttpRequest, content_type_id: int, action: str) -> 
 
     return definition.renderer_cls.handle_action(action, request, state)
     
-

--- a/bloomerp/django_bloomerp/bloomerp/dataviews/table.py
+++ b/bloomerp/django_bloomerp/bloomerp/dataviews/table.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from django.core.exceptions import FieldDoesNotExist
 from django.db.models import QuerySet
 from django.http import HttpRequest
 
@@ -23,17 +24,26 @@ class TableDataviewRenderer(BaseDataviewRenderer):
         return context
 
     @staticmethod
-    def _get_sortable_fields_by_name(dataview_fields) -> dict:
+    def _get_sortable_fields_by_name(queryset: QuerySet, dataview_fields) -> dict:
         if hasattr(dataview_fields, "accessible_fields"):
-            return {
-                field.field: field
+            application_fields = [
+                field
                 for field, _is_visible in dataview_fields.accessible_fields
-            }
+            ]
+        else:
+            application_fields = list(dataview_fields.visible_fields)
 
-        return {
-            field.field: field
-            for field in dataview_fields.visible_fields
-        }
+        sortable_fields = {}
+        for application_field in application_fields:
+            try:
+                model_field = queryset.model._meta.get_field(application_field.field)
+            except FieldDoesNotExist:
+                continue
+
+            if getattr(model_field, "concrete", False):
+                sortable_fields[application_field.field] = application_field
+
+        return sortable_fields
 
     @classmethod
     def apply_sorting(
@@ -45,7 +55,7 @@ class TableDataviewRenderer(BaseDataviewRenderer):
     ) -> tuple[QuerySet, dict]:
         sort_field = request.GET.get("sort") or getattr(options, "sort_field", None)
         sort_direction = request.GET.get("direction") or getattr(options, "sort_direction", "asc") or "asc"
-        sortable_fields_by_name = cls._get_sortable_fields_by_name(dataview_fields)
+        sortable_fields_by_name = cls._get_sortable_fields_by_name(queryset, dataview_fields)
 
         context = {
             "current_sort_field": "",

--- a/bloomerp/django_bloomerp/bloomerp/tests/components/dataview.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/components/dataview.py
@@ -7,7 +7,7 @@ from django.utils import timezone
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.auth.models import Permission
 from bloomerp.tests.base import BaseBloomerpModelTestCase
-from bloomerp.models import ApplicationField
+from bloomerp.models import ApplicationField, Todo
 from bloomerp.models import Policy, FieldPolicy, RowPolicy, RowPolicyRule
 from bloomerp.models.users.user_list_view_preference import UserListViewPreference
 from bloomerp.services.user_services import get_data_view_fields, get_user_list_view_preference
@@ -315,6 +315,46 @@ class TestDataView(BaseBloomerpModelTestCase):
         self.assertLess(content.index("Alice"), content.index("Bob"))
         self.assertLess(content.index("Bob"), content.index("Charlie"))
         self.assertContains(response, 'aria-sort="ascending"', html=False)
+
+    def test_table_dataview_ignores_sorting_by_generic_foreign_key(self):
+        """
+        Use case: A content object field is added to a user's table preference.
+        Expected result: The table renders the linked object without ordering by
+        the virtual field.
+        """
+        # 1. Create a todo linked to a model object through its GenericForeignKey.
+        customer = self.create_customer("Generic", "Relation", 30)
+        Todo.objects.create(title="Linked todo", content_object=customer)
+
+        # 2. Make content_object the visible field in the selected Todo preference.
+        self.client.force_login(self.admin_user)
+        content_type = ContentType.objects.get_for_model(Todo)
+        content_object_field = ApplicationField.get_by_field(Todo, "content_object")
+        preference = get_user_list_view_preference(self.admin_user, content_type)
+        preference.display_fields = {
+            **preference.display_fields,
+            "table": [content_object_field.id],
+        }
+        preference.save(update_fields=["display_fields"])
+
+        # 3. Request the table after adding the virtual field to the preference.
+        dataview_url = reverse(
+            viewname="components_dataview",
+            kwargs={"content_type_id": content_type.id},
+        )
+        response = self.client.get(dataview_url, HTTP_HX_REQUEST="true")
+
+        # 4. Confirm the virtual field does not break rendering and shows its value.
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Generic Relation")
+
+        # 5. Confirm a stale or manually supplied sort query cannot break the table.
+        sorted_response = self.client.get(
+            f"{dataview_url}?sort=content_object&direction=asc",
+            HTTP_HX_REQUEST="true",
+        )
+        self.assertEqual(sorted_response.status_code, 200)
+        self.assertContains(sorted_response, "Generic Relation")
 
     def test_table_sort_links_preserve_filters_and_reset_page(self):
         self.client.force_login(self.admin_user)


### PR DESCRIPTION
Todo: …30a2 — Bug when adding content object field to user list view preference

## Summary
- exclude virtual GenericForeignKey fields from select_related eager loading
- allow sorting only on concrete database-backed fields
- add regression coverage for rendering and stale sorting requests with Todo.content_object

## Verification
- PASS: focused dataview regression and adjacent sorting/eager-loading tests (4 tests)
- PASS: python manage.py check
- PASS: Python compilation and git diff --check
- KNOWN FAILURE: the broader TestDataView suite has one pre-existing failure in test_list_view_with_init_filters_includes_filter_box; it reproduces alone and is unrelated to this change

## Todo automation
- Assignment and in-review updates could not be performed because BLOOMERP_TODO_API_KEY is unavailable in this runtime.