### PR TITLE
Fix dataview field visibility button state

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/update_preference.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/objects/dataviews/update_preference.py
@@ -35,6 +35,10 @@ def _change_data_view_field_visibility(
             return HttpResponse("Permission denied", status=403)
 
         toggle_field_visibility(request.user, content_type, field_id, view_type)
+        # toggle_field_visibility loads and saves the selected preference through
+        # PreferenceManager. Refresh this request's instance so the response does
+        # not render the field button state from one click behind.
+        preference.refresh_from_db(fields=["display_fields"])
     except (ValueError, ApplicationField.DoesNotExist) as e:
         return HttpResponse(f"Invalid field: {e}", status=400)
 

--- a/bloomerp/django_bloomerp/bloomerp/tests/components/dataview.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/components/dataview.py
@@ -1,4 +1,5 @@
 import json
+import re
 from datetime import date, datetime, timedelta
 
 from django.db import models
@@ -791,6 +792,54 @@ class TestDataView(BaseBloomerpModelTestCase):
 
         selected.refresh_from_db()
         self.assertEqual(selected.options["table"]["page_size"], 50)
+
+    def test_change_field_visibility_response_uses_updated_preference(self):
+        """
+        Use case: A user hides a currently visible dataview field.
+        Expected result: The first POST response renders that field as unselected.
+        """
+        # 1. Create a selected table preference with two visible fields.
+        self.client.force_login(self.admin_user)
+        content_type = ContentType.objects.get_for_model(self.CustomerModel)
+        first_name_field = ApplicationField.get_by_field(self.CustomerModel, "first_name")
+        last_name_field = ApplicationField.get_by_field(self.CustomerModel, "last_name")
+        preference = PreferenceManager(self.admin_user).get_or_create_selected(
+            UserListViewPreference,
+            scope={"content_type_id": content_type.id},
+        )
+        preference.set_visible_field_ids(
+            "table",
+            [first_name_field.id, last_name_field.id],
+        )
+        preference.save(update_fields=["display_fields"])
+
+        # 2. Hide the first field through the display-options component endpoint.
+        url = reverse(
+            viewname="components_update_dataview_preference",
+            kwargs={"content_type_id": content_type.id},
+        )
+        response = self.client.post(
+            url,
+            data={
+                "toggle_field_id": first_name_field.id,
+                "toggle_view_type": "table",
+            },
+            HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+        )
+
+        # 3. Verify persistence and the HTML returned by this same request.
+        self.assertEqual(response.status_code, 200)
+        preference.refresh_from_db()
+        self.assertNotIn(first_name_field.id, preference.get_visible_field_ids("table"))
+        response_html = response.content.decode()
+        first_name_button = re.search(
+            rf'data-display-options-values=\'\{{"toggle_field_id": "{first_name_field.id}".*?class="([^"]+)"',
+            response_html,
+            re.DOTALL,
+        )
+        self.assertIsNotNone(first_name_button)
+        self.assertIn("bg-white", first_name_button.group(1))
+        self.assertNotIn("bg-primary-100", first_name_button.group(1))
 
 
 class TestGantDataView(BaseBloomerpModelTestCase):

--- a/bloomerp/django_bloomerp/bloomerp/tests/e2e/dataview/test_dataview_display_options.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/e2e/dataview/test_dataview_display_options.py
@@ -1,0 +1,72 @@
+import re
+
+from django.contrib.contenttypes.models import ContentType
+from playwright.sync_api import expect
+
+from bloomerp.models import ApplicationField
+from bloomerp.models.project_management.todo import Todo
+from bloomerp.models.users.user_list_view_preference import UserListViewPreference
+from bloomerp.services.preference_services import PreferenceManager
+from bloomerp.tests.e2e.dataview.test_dataview_e2e_mixin import TestDataviewE2EMixin
+
+
+class TestDataviewDisplayOptionsE2E(TestDataviewE2EMixin):
+    def extendedE2ESetup(self) -> None:
+        content_type = ContentType.objects.get_for_model(Todo)
+        self.title_field = ApplicationField.get_by_field(Todo, "title")
+        self.status_field = ApplicationField.get_by_field(Todo, "status")
+        self.priority_field = ApplicationField.get_by_field(Todo, "priority")
+
+        preference = PreferenceManager(self.admin_user).get_or_create_selected(
+            UserListViewPreference,
+            scope={"content_type_id": content_type.id},
+        )
+        preference.view_type = "table"
+        preference.set_visible_field_ids(
+            "table",
+            [self.title_field.id, self.status_field.id],
+        )
+        preference.save(update_fields=["view_type", "display_fields"])
+        Todo.objects.create(title="Display options regression")
+        self.login_as_admin()
+
+    def test_field_buttons_and_columns_update_on_first_click(self):
+        """
+        Use case: A user changes visible fields from the Todo table display options.
+        Expected result: Button colors and table columns reflect every click immediately.
+        """
+        # 1. Open a Todo table where Title is visible and Priority is hidden.
+        self.goto_todo_page()
+        table_header = self.page.locator("#data-view-data-section table thead")
+        expect(table_header.get_by_role("button", name="Title", exact=True)).to_have_count(1)
+        expect(table_header.get_by_role("button", name="Priority", exact=True)).to_have_count(0)
+
+        # 2. Open display options and confirm both buttons' initial colors.
+        self.page.get_by_role("button", name="Display").click()
+        display_menu = self.page.locator("div[role='menu']:visible").filter(
+            has=self.page.locator("button[data-display-options-values*='\"view_type\": \"table\"']")
+        )
+        title_option = display_menu.get_by_role("button", name="Title", exact=True)
+        priority_option = display_menu.get_by_role("button", name="Priority", exact=True)
+        expect(title_option).to_have_class(re.compile(r"\bbg-primary-100\b"))
+        expect(priority_option).to_have_class(re.compile(r"\bbg-white\b"))
+
+        # 3. Hide Title and verify its button and column change on the first response.
+        with self.expect_response_for(
+            f"/components/change_data_view_preference/{ContentType.objects.get_for_model(Todo).id}/",
+            method="POST",
+        ):
+            title_option.click()
+        expect(title_option).to_have_class(re.compile(r"\bbg-white\b"))
+        expect(title_option).not_to_have_class(re.compile(r"\bbg-primary-100\b"))
+        expect(table_header.get_by_role("button", name="Title", exact=True)).to_have_count(0)
+
+        # 4. Show Priority and verify its button and column change on the first response.
+        with self.expect_response_for(
+            f"/components/change_data_view_preference/{ContentType.objects.get_for_model(Todo).id}/",
+            method="POST",
+        ):
+            priority_option.click()
+        expect(priority_option).to_have_class(re.compile(r"\bbg-primary-100\b"))
+        expect(priority_option).not_to_have_class(re.compile(r"\bbg-white\b"))
+        expect(table_header.get_by_role("button", name="Priority", exact=True)).to_have_count(1)


### PR DESCRIPTION
## To-do

- ID: `c146cced-5d3b-423c-b889-3b12982151dc`
- Title: [BUG] When changing field visibility in dataview, the button doesn't change color

## Root cause

Field visibility was persisted through a freshly loaded selected preference, while the component response was rendered from an older in-memory preference instance. The dataview refreshed from the saved state, but the display-options button HTML lagged one interaction behind.

## Summary

- Refreshes the request's preference after toggling a field so the same POST response renders the current selected state.
- Preserves the existing field-permission check and preference-management behavior.
- Adds a focused component regression test for the first response.
- Adds the requested Todo dataview Playwright test covering selected/unselected button colors and removed/added columns.

## Impact

Visible-field buttons now change color immediately on the first click and stay synchronized with the table columns.

## Validation

- `uv run python manage.py test bloomerp.tests.components.dataview.TestDataView.test_change_field_visibility_response_uses_updated_preference` — passed
- `uv run python manage.py test bloomerp.tests.e2e.dataview.test_dataview_display_options.TestDataviewDisplayOptionsE2E.test_field_buttons_and_columns_update_on_first_click` — passed
- `uv run python -m py_compile bloomerp/components/objects/dataviews/update_preference.py bloomerp/tests/components/dataview.py bloomerp/tests/e2e/dataview/test_dataview_display_options.py` — passed
- Full `TestDataView` class: 19 passed, 1 unrelated existing failure. `test_list_view_with_init_filters_includes_filter_box` also fails when run alone because the expected initial-filter badge is absent; this PR does not touch filter handling.