### PR TITLE
Fix dataview split-view object saving

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/tests/e2e/dataview/test_dataview_split_view.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/e2e/dataview/test_dataview_split_view.py
@@ -1,0 +1,60 @@
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from bloomerp.models.application_field import ApplicationField
+from bloomerp.models.project_management.todo import Todo
+from bloomerp.models.users.user_list_view_preference import UserListViewPreference
+from bloomerp.services.preference_services import PreferenceManager
+from bloomerp.tests.e2e.dataview.test_dataview_e2e_mixin import (
+    TestDataviewE2EMixin,
+)
+from bloomerp.utils.models import get_detail_view_url
+
+
+class TestDataviewSplitViewE2E(TestDataviewE2EMixin):
+    def extendedE2ESetup(self):
+        pass
+
+    def test_saves_an_object_from_the_split_view(self):
+        """
+        Use case: An admin edits a Todo from the dataview split view.
+        Expected result: Saving updates the Todo without an HTMX target error.
+        """
+        # 1. Enable split view and display the Todo title in the table.
+        content_type = ContentType.objects.get_for_model(Todo)
+        title_field = ApplicationField.get_by_field(Todo, "title")
+        preference = PreferenceManager(self.admin_user).get_or_create_selected(
+            UserListViewPreference,
+            scope={"content_type_id": content_type.pk},
+        )
+        preference.view_type = "table"
+        preference.split_view_enabled = True
+        preference.display_fields = {
+            **preference.display_fields,
+            "table": [title_field.pk],
+        }
+        preference.save()
+        todo = Todo.objects.create(title="Split view original")
+
+        # 2. Open the Todo dataview and load the object into the detail pane.
+        self.login_as_admin()
+        self.goto_todo_page()
+        detail_path = reverse(
+            get_detail_view_url(Todo),
+            kwargs={"pk": todo.pk},
+        )
+        title_cell = self.page.locator(
+            f'td[data-object-id="{todo.pk}"][data-application-field-name="title"]'
+        )
+        with self.expect_response_for(detail_path, method="GET"):
+            title_cell.dblclick()
+
+        # 3. Change the title and save from inside the split-view detail pane.
+        detail_pane = self.page.locator("[data-split-view-detail-pane]")
+        detail_pane.locator("#id_title").fill("Split view updated")
+        with self.expect_response_for(detail_path, method="POST"):
+            detail_pane.get_by_role("button", name="Save", exact=True).click()
+
+        # 4. Verify the object was persisted.
+        todo.refresh_from_db()
+        self.assertEqual(todo.title, "Split view updated")

--- a/bloomerp/django_bloomerp/bloomerp/views/mixins/layout_model_form_mixin.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/mixins/layout_model_form_mixin.py
@@ -69,7 +69,14 @@ class LayoutModelFormMixin(ApplicationFieldLayoutFormMixin, ABC):
         return self.get_form_instance()
 
     def get_form_hx_target(self) -> str:
-        return "#main-content" if self.is_create_layout() else "#detail-view-content"
+        if self.is_create_layout():
+            return "#main-content"
+
+        htmx_target = getattr(getattr(self.request, "htmx", None), "target", None)
+        if htmx_target == "data-table-detail-pane":
+            return "#data-table-detail-pane"
+
+        return "#detail-view-content"
 
     def get_form_hx_push_url(self) -> bool:
         return self.is_create_layout()


### PR DESCRIPTION
## What changed

- target split-view update forms at the dataview detail pane that rendered them
- preserve the existing full-page detail and create form targets
- add a Playwright regression covering opening, editing, and saving a Todo from split view

## Root cause

Split-view detail requests render the object form directly into `#data-table-detail-pane`, without the normal `#detail-view-content` wrapper. The form still targeted that absent wrapper on submit, so HTMX raised `htmx:targetError` and never sent the update request.

## Validation

- focused split-view Playwright regression
- existing full-page detail update Playwright test
- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- Python compilation for the changed implementation and test