### PR TITLE
Fix nested text-editor bullet markers

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/text_editor/BloomerpTextEditor.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/text_editor/BloomerpTextEditor.ts
@@ -104,6 +104,9 @@ export class BloomerpTextEditor extends BaseWidget {
                 list: {
                     ul: !this.overrideDefaultStyling ? 'list-disc list-inside pl-4' : '',
                     ol: !this.overrideDefaultStyling ? 'list-decimal list-inside pl-4' : '',
+                    nested: {
+                        listitem: 'list-none',
+                    },
                 },
                 table: !this.overrideDefaultStyling ? 'my-3 w-full table-fixed border-collapse overflow-hidden rounded-lg border border-gray-200 text-left' : '',
                 tableRow: !this.overrideDefaultStyling ? 'border-b border-gray-200 last:border-b-0' : '',


### PR DESCRIPTION
## To-do

- ID: `dc134755-57ed-474d-8848-32752a47137e`
- Title: `[BUG] Text editor bullet points`

## What changed

Configured Lexical's nested list-item theme to apply `list-none` to structural list wrappers. Real list items retain their normal bullets or numbering, while the wrapper used for an indented child list no longer renders an extra unselectable marker.

## Root cause

Lexical represents nested lists with a structural `<li>` containing the child list. Without a `list.nested.listitem` theme class, the browser rendered a marker for that non-content wrapper.

## Validation

- `npm run type-check` — passed
- `npm run build` — passed (existing third-party bundler and chunk-size warnings only)
- Automated tests were not added because the to-do explicitly requests user acceptance testing instead.