### PR TITLE
Change home view behavior

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/workspaces/container.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/workspaces/container.html
@@ -64,7 +64,7 @@
                 hx-push-url="true"
                 hx-swap="innerHTML"
             >
-                <i class="fa-solid fa-grid-2"></i>
+                <i class="fa fa-puzzle-piece"></i>
                 <c-i18n.blocktrans>Select module</c-i18n.blocktrans>
             </button>
         {% endif %}

--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/workspaces/container.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/workspaces/container.html
@@ -55,6 +55,20 @@
     </c-slot>
     
     <c-slot name="buttons_right">
+        {% if show_module_selector %}
+            <button
+                type="button"
+                class="btn btn-secondary btn-sm"
+                hx-get="{% url 'bloomerp_home_view' %}?modules=1"
+                hx-target="#main-content"
+                hx-push-url="true"
+                hx-swap="innerHTML"
+            >
+                <i class="fa-solid fa-grid-2"></i>
+                <c-i18n.blocktrans>Select module</c-i18n.blocktrans>
+            </button>
+        {% endif %}
+
         <c-ui.shortcut_tooltip position="bottom" shortcut="mod+6">
             <c-features.preferences.select_preference_button
                 model="Workspace"

--- a/bloomerp/django_bloomerp/bloomerp/templates/views/workspaces/bloomerp_home_view.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/views/workspaces/bloomerp_home_view.html
@@ -1,22 +1,39 @@
-<div class="flex justify-center mt-14">
-    <div class="container mx-auto px-4">
-        <div class="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-4 gap-8 justify-center">
-        {% for module in modules %}
-            <a 
-                hx-get="/{{ module.id }}/"
-                hx-target="#main-content"
-                hx-push-url="true"
-                hx-swap="innerHTML"
-            >
-                <div class="h-full border hover:cursor-pointer border-gray-200 bg-white text-primary-900 rounded-xl p-4 flex flex-col items-center justify-center gap-3 hover:shadow-md transition-transform duration-150 ease-in-out transform hover:-translate-y-1">
-                        <div class="flex items-center justify-center w-12 h-12 rounded-full bg-gradient-to-br bg-primary-50 text-primary-700 shadow">
-                            <i class="fas {{module.icon}} fa-lg"></i>
-                        </div>
-                        <span class="text-sm font-semibold tracking-wide">{{ module.name }}</span>
-                        <c-ui.text.muted class="mt-2 text-xs text-center">{{ module.description }}</c-ui.text.muted>
-                </div>
-            </a>
-        {% endfor %}
+{% if workspace %}
+    <div class="mb-4 flex justify-end">
+        <button
+            type="button"
+            class="btn btn-secondary btn-sm"
+            hx-get="{% url 'bloomerp_home_view' %}?modules=1"
+            hx-target="#main-content"
+            hx-push-url="true"
+            hx-swap="innerHTML"
+        >
+            <i class="fa-solid fa-grid-2"></i>
+            <c-i18n.blocktrans>Select module</c-i18n.blocktrans>
+        </button>
+    </div>
+    {% include "views/workspaces/bloomerp_workspace_view.html" %}
+{% else %}
+    <div class="flex justify-center mt-14">
+        <div class="container mx-auto px-4">
+            <div class="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-4 gap-8 justify-center">
+            {% for module in modules %}
+                <a
+                    hx-get="/{{ module.id }}/"
+                    hx-target="#main-content"
+                    hx-push-url="true"
+                    hx-swap="innerHTML"
+                >
+                    <div class="h-full border hover:cursor-pointer border-gray-200 bg-white text-primary-900 rounded-xl p-4 flex flex-col items-center justify-center gap-3 hover:shadow-md transition-transform duration-150 ease-in-out transform hover:-translate-y-1">
+                            <div class="flex items-center justify-center w-12 h-12 rounded-full bg-gradient-to-br bg-primary-50 text-primary-700 shadow">
+                                <i class="fas {{ module.icon }} fa-lg"></i>
+                            </div>
+                            <span class="text-sm font-semibold tracking-wide">{{ module.name }}</span>
+                            <c-ui.text.muted class="mt-2 text-xs text-center">{{ module.description }}</c-ui.text.muted>
+                    </div>
+                </a>
+            {% endfor %}
+            </div>
         </div>
     </div>
-</div>
+{% endif %}

--- a/bloomerp/django_bloomerp/bloomerp/templates/views/workspaces/bloomerp_home_view.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/views/workspaces/bloomerp_home_view.html
@@ -1,17 +1,4 @@
 {% if workspace %}
-    <div class="mb-4 flex justify-end">
-        <button
-            type="button"
-            class="btn btn-secondary btn-sm"
-            hx-get="{% url 'bloomerp_home_view' %}?modules=1"
-            hx-target="#main-content"
-            hx-push-url="true"
-            hx-swap="innerHTML"
-        >
-            <i class="fa-solid fa-grid-2"></i>
-            <c-i18n.blocktrans>Select module</c-i18n.blocktrans>
-        </button>
-    </div>
     {% include "views/workspaces/bloomerp_workspace_view.html" %}
 {% else %}
     <div class="flex justify-center mt-14">

--- a/bloomerp/django_bloomerp/bloomerp/tests/views/test_home.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/views/test_home.py
@@ -1,0 +1,174 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from django.test import TestCase
+from django.urls import reverse
+
+from bloomerp.models import User, Workspace
+
+
+class HomeViewTests(TestCase):
+    def setUp(self) -> None:
+        self.owner = User.objects.create_user(
+            username="home-workspace-owner",
+            password="testpass123",
+            is_staff=True,
+        )
+        self.user = User.objects.create_user(
+            username="home-workspace-user",
+            password="testpass123",
+            is_staff=True,
+        )
+        self.client.force_login(self.user)
+        self.url = reverse("bloomerp_home_view")
+        self.module = SimpleNamespace(
+            id="staff",
+            name="Staff",
+            description="Staff module",
+            icon="fa-users",
+        )
+
+    def create_workspace(self, **kwargs) -> Workspace:
+        return Workspace.objects.create(
+            layout={"rows": [{"title": "Home", "columns": 4, "items": []}]},
+            **kwargs,
+        )
+
+    def get_home(self, query: str = ""):
+        return self.client.get(
+            f"{self.url}{query}",
+            HTTP_HX_REQUEST="true",
+            HTTP_HX_TARGET="main-content",
+        )
+
+    @patch("bloomerp.views.workspaces.home.module_registry.get_root_modules")
+    def test_home_without_general_workspace_shows_modules(self, get_root_modules) -> None:
+        """
+        Use case: A user without a general workspace opens the home view.
+        Expected result: The existing module selector remains available.
+        """
+        # 1. Configure a visible root module for the selector.
+        get_root_modules.return_value = [self.module]
+
+        # 2. Open the home view and verify the fallback module selector.
+        response = self.get_home()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Staff module")
+        self.assertNotContains(response, "Select module")
+
+    @patch("bloomerp.views.workspaces.home.module_registry.get_root_modules")
+    def test_module_workspace_does_not_replace_home_view(self, get_root_modules) -> None:
+        """
+        Use case: A user has a selected workspace scoped to the Staff module.
+        Expected result: Home still shows modules because module and home selections are independent.
+        """
+        # 1. Create a selected workspace in the Staff module scope only.
+        self.create_workspace(
+            user=self.user,
+            name="Staff workspace",
+            module_id="staff",
+            selected=True,
+        )
+        get_root_modules.return_value = [self.module]
+
+        # 2. Open home and verify the Staff module card is rendered instead.
+        response = self.get_home()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Staff module")
+        self.assertNotContains(response, "Staff workspace")
+
+    @patch("bloomerp.views.workspaces.home.module_registry.get_root_modules")
+    def test_selected_general_workspace_replaces_module_selector(self, get_root_modules) -> None:
+        """
+        Use case: A user has selected a general workspace as their home preference.
+        Expected result: Home renders that workspace with an option to select a module.
+        """
+        # 1. Create the user's selected general workspace.
+        self.create_workspace(
+            user=self.user,
+            name="My home workspace",
+            module_id=None,
+            selected=True,
+        )
+        get_root_modules.return_value = [self.module]
+
+        # 2. Open home and verify the workspace replaces the module cards.
+        response = self.get_home()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "My home workspace")
+        self.assertContains(response, "Select module")
+        self.assertNotContains(response, "Staff module")
+
+    def test_shared_initial_default_becomes_user_home_workspace(self) -> None:
+        """
+        Use case: An administrator shares a general workspace as an initial default.
+        Expected result: The recipient sees it at home and receives a selected live reference.
+        """
+        # 1. Create and share an initial-default general workspace.
+        shared = self.create_workspace(
+            user=self.owner,
+            name="Timesheet home",
+            module_id=None,
+            initial_default=True,
+        )
+        shared.shared_with_users.add(self.user)
+
+        # 2. Open home and verify the shared workspace is selected and rendered.
+        response = self.get_home()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Timesheet home")
+        reference = Workspace.objects.get(user=self.user, source_object=shared)
+        self.assertTrue(reference.selected)
+
+    @patch("bloomerp.views.workspaces.home.module_registry.get_root_modules")
+    def test_select_module_query_temporarily_shows_modules(self, get_root_modules) -> None:
+        """
+        Use case: A user with a home workspace chooses Select module.
+        Expected result: The module selector is rendered without changing their preference.
+        """
+        # 1. Create the user's selected general workspace.
+        workspace = self.create_workspace(
+            user=self.user,
+            name="My home workspace",
+            module_id=None,
+            selected=True,
+        )
+        get_root_modules.return_value = [self.module]
+
+        # 2. Request the module-selector override and verify selection is preserved.
+        response = self.get_home("?modules=1")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Staff module")
+        self.assertNotContains(response, "My home workspace")
+        workspace.refresh_from_db()
+        self.assertTrue(workspace.selected)
+
+    @patch("bloomerp.views.workspaces.home.module_registry.get_root_modules")
+    def test_revoked_shared_workspace_falls_back_to_modules(self, get_root_modules) -> None:
+        """
+        Use case: Access to a previously selected shared home workspace is revoked.
+        Expected result: Home no longer renders it and safely falls back to modules.
+        """
+        # 1. Select a shared initial-default workspace, then revoke its sharing.
+        shared = self.create_workspace(
+            user=self.owner,
+            name="Revoked home",
+            module_id=None,
+            initial_default=True,
+        )
+        shared.shared_with_users.add(self.user)
+        self.get_home()
+        shared.shared_with_users.remove(self.user)
+        get_root_modules.return_value = [self.module]
+
+        # 2. Reopen home and verify inaccessible workspace content is not rendered.
+        response = self.get_home()
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Staff module")
+        self.assertNotContains(response, "Revoked home")

--- a/bloomerp/django_bloomerp/bloomerp/views/workspaces/home.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/workspaces/home.py
@@ -1,7 +1,10 @@
 from django.views.generic import TemplateView
-from bloomerp.views.base import BaseBloomerpView
-from bloomerp.router import router
+
+from bloomerp.models.workspaces.workspace import Workspace
 from bloomerp.modules.definition import module_registry
+from bloomerp.router import router
+from bloomerp.services.preference_services import PreferenceManager
+from bloomerp.views.workspaces.base import BaseWorkspaceView
 
 
 @router.register(
@@ -11,17 +14,31 @@ from bloomerp.modules.definition import module_registry
     route_type='app',
     url_name='bloomerp_home_view'
 )
-class BloomerpHomeView(BaseBloomerpView, TemplateView):
-    template_name = 'views/workspaces/bloomerp_home_view.html'
+class BloomerpHomeView(BaseWorkspaceView, TemplateView):
+    template_name = "views/workspaces/bloomerp_home_view.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["modules"] = module_registry.get_root_modules()
+        workspace = self.get_workspace()
+
+        if workspace:
+            context.update(self.get_workspace_template_context())
+        else:
+            context["modules"] = module_registry.get_root_modules()
+
         return context
 
+    def get_module_id(self) -> None:
+        """Return the unscoped module id used by general workspaces."""
+        return None
 
+    def get_workspace(self) -> Workspace | None:
+        """Return the selected general workspace unless modules were requested."""
+        if self.request.GET.get("modules") == "1":
+            return None
 
-        
-
-
-    
+        return PreferenceManager(self.request.user).get_or_create_selected(
+            Workspace,
+            {"module_id": None},
+            force_create=False,
+        )

--- a/bloomerp/django_bloomerp/bloomerp/views/workspaces/home.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/workspaces/home.py
@@ -23,6 +23,7 @@ class BloomerpHomeView(BaseWorkspaceView, TemplateView):
 
         if workspace:
             context.update(self.get_workspace_template_context())
+            context["show_module_selector"] = True
         else:
             context["modules"] = module_registry.get_root_modules()
 

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.12.0beta21"
+version = "1.12.0beta22"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## To-do

- ID: bfaa2577-9691-4979-9d25-4f7eac4d6aeb
- Title: Change home view behavior

## Summary

- Render a user's selected general workspace on the application home view.
- Preserve the module selector when no general workspace is available.
- Add a Select module escape hatch without changing the saved workspace preference.
- Reuse existing workspace sharing and initial-default preference behavior.
- Safely fall back to modules when access to a shared workspace is revoked.

## Tests

- uv run python manage.py test bloomerp.tests.views.test_home — passed (6 tests).
- uv run python manage.py test bloomerp.tests.views.test_home bloomerp.tests.models.test_workspace bloomerp.tests.services.test_preference_services — passed (25 tests).
- PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py check — passed.
- PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py makemigrations --check --dry-run — passed; no changes detected.