### PR TITLE
fix: respect one-to-many column defaults

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/OneToManyFieldWidget.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/OneToManyFieldWidget.ts
@@ -186,7 +186,10 @@ export default class OneToManyFieldWidget extends BaseWidget {
             this.replacePrefix(fragment, rowIndex);
             const rowElement = fragment.querySelector<HTMLElement>("[data-one-to-many-row]");
             if (rowElement) {
-                this.applyRowData(rowElement, rowData);
+                this.applyRowData(rowElement, {
+                    ...this.getDefaultRowData(),
+                    ...rowData,
+                });
             }
             this.tbody?.appendChild(fragment);
         });
@@ -256,7 +259,10 @@ export default class OneToManyFieldWidget extends BaseWidget {
         this.tbody.querySelector("[data-one-to-many-empty-row]")?.remove();
         const rowElement = fragment.querySelector<HTMLElement>("[data-one-to-many-row]");
         if (rowElement) {
-            this.applyRowData(rowElement, rowData);
+            this.applyRowData(rowElement, {
+                ...this.getDefaultRowData(),
+                ...rowData,
+            });
         }
         const appendedNodes = Array.from(fragment.children);
         this.tbody.appendChild(fragment);
@@ -388,6 +394,31 @@ export default class OneToManyFieldWidget extends BaseWidget {
         });
     }
 
+    private getDefaultRowData(): OneToManyRowState {
+        if (!this.element) return {};
+
+        const defaults: OneToManyRowState = {};
+        this.element.querySelectorAll<HTMLElement>("[data-one-to-many-column]").forEach((column) => {
+            const fieldName = column.dataset.oneToManyColumn;
+            const serializedValue = column.dataset.columnDefaultValue;
+            if (!fieldName || !serializedValue) return;
+
+            try {
+                const value = JSON.parse(serializedValue) as unknown;
+                if (Array.isArray(value)) {
+                    defaults[fieldName] = value.map((item) => String(item));
+                } else if (value && typeof value === "object") {
+                    defaults[fieldName] = JSON.stringify(value);
+                } else {
+                    defaults[fieldName] = value == null ? "" : String(value);
+                }
+            } catch {
+                defaults[fieldName] = serializedValue;
+            }
+        });
+        return defaults;
+    }
+
     private applyRowData(rowElement: HTMLElement, rowData: OneToManyRowState): void {
         const fields = rowElement.querySelectorAll<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>(
             "input[name], textarea[name], select[name]",
@@ -407,7 +438,9 @@ export default class OneToManyFieldWidget extends BaseWidget {
             if (field instanceof HTMLInputElement && field.type === "checkbox") {
                 field.checked = Array.isArray(value)
                     ? value.includes(field.value)
-                    : value === (field.value || "on");
+                    : value === "true"
+                        || value === "1"
+                        || value === (field.value || "on");
                 return;
             }
 

--- a/bloomerp/django_bloomerp/bloomerp/templates/widgets/one_to_many_field_widget.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/widgets/one_to_many_field_widget.html
@@ -18,7 +18,11 @@
                     <input type="checkbox" data-one-to-many-select-all {% if not can_edit %}disabled{% endif %}>
                 </th>
                 {% for column in columns %}
-                    <th data-one-to-many-column="{{ column.field }}" data-column-kind="{{ column.kind }}">
+                    <th
+                        data-one-to-many-column="{{ column.field }}"
+                        data-column-kind="{{ column.kind }}"
+                        data-column-default-value="{{ column.default_value_json }}"
+                    >
                         <div class="flex items-center justify-between gap-2">
                             <span>{{ column.title }}</span>
                             <c-ui.inputs.one_to_many.column_actions :column="column" :can_edit="can_edit" />

--- a/bloomerp/django_bloomerp/bloomerp/tests/e2e/generic/test_field_behavior_e2e.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/e2e/generic/test_field_behavior_e2e.py
@@ -12,6 +12,7 @@ from bloomerp.form_fields.behavior import (
     BehaviorRule,
     ClearValueAction,
     CopyValueFromOneToManyAction,
+    PopulateRowsAction,
     SetValueAction,
 )
 from bloomerp.models.application_field import ApplicationField
@@ -78,6 +79,7 @@ class TestFieldBehaviorE2E(TestCrudE2EMixin, BaseE2ETestCase):
             ]
         ).model_dump()
         self.country_preference.save(update_fields=["layout"])
+        self.CustomerModel._meta.get_field("age").default = 42
         self.login_as_admin()
 
     def get_country_field(self, field_name: str) -> ApplicationField:
@@ -259,6 +261,40 @@ class TestFieldBehaviorE2E(TestCrudE2EMixin, BaseE2ETestCase):
 
         # 3. Verify the target contains the row count.
         expect(self.locate_field("name")).to_have_value("2")
+
+    def test_populate_related_rows_uses_column_defaults(self):
+        """
+        Use case: Populate blank related rows through a form behavior.
+        Expected result: Each generated row uses the related model column default.
+        """
+        # 1. Configure the Planet change to create two Customer rows.
+        customers_field = self.get_country_field("customers")
+        self.configure_country_behavior(
+            source_field_name="planet",
+            rules=[
+                BehaviorRule(
+                    events=[BehaviorEvent.CHANGE],
+                    actions=[
+                        PopulateRowsAction(
+                            target_field=str(customers_field.pk),
+                            row_count=2,
+                        )
+                    ],
+                )
+            ],
+        )
+
+        # 2. Change the source field to trigger the populate-related-rows behavior.
+        self.goto(self.get_country_create_url())
+        self.select_foreign_value("planet", "Earth")
+
+        # 3. Verify both generated Customer rows received the age default.
+        customers_widget = self.page.locator('[data-one-to-many-name="customers"]')
+        age_inputs = customers_widget.locator(
+            '[data-one-to-many-cell="age"] input'
+        )
+        expect(age_inputs).to_have_count(2)
+        self.assertEqual([input_.input_value() for input_ in age_inputs.all()], ["42", "42"])
 
     def test_sum_of_numeric_field_can_be_extracted_from_o2m_field(self):
         """

--- a/bloomerp/django_bloomerp/bloomerp/tests/e2e/widgets/test_one_to_many_widget_e2e.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/e2e/widgets/test_one_to_many_widget_e2e.py
@@ -50,6 +50,7 @@ class TestOneToManyWidgetE2E(TestCrudE2EMixin, BaseE2ETestCase):
         ).model_dump()
         preference.save(update_fields=["layout"])
         self.customer_type = self.CustomerTypeModel.objects.get(name="Retail")
+        self.CustomerModel._meta.get_field("age").default = 42
         self.login_as_admin()
 
     def get_base_url(self) -> str:
@@ -157,6 +158,26 @@ class TestOneToManyWidgetE2E(TestCrudE2EMixin, BaseE2ETestCase):
                 '[data-one-to-many-cell="customer_type"] .foreign-field-selected'
             )
         ).to_contain_text("Retail")
+
+    def test_add_and_clone_rows_use_column_defaults(self):
+        """
+        Use case: Add and clone rows when a related column has a model default.
+        Expected result: New rows use the default while clones preserve explicit values.
+        """
+        # 1. Open a form with a prefilled row that omits the defaulted age.
+        self.goto(self.get_url_with_rows([{"first_name": "Ada"}]))
+        self.assertEqual(self.get_column_values("age"), ["42"])
+
+        # 2. Add a row and verify the default is applied to it.
+        self.get_widget().get_by_role("button", name="Add row").click()
+        self.assertEqual(self.get_column_values("age"), ["42", "42"])
+
+        # 3. Change the first value and clone the row.
+        self.get_rows().nth(0).locator('[data-one-to-many-cell="age"] input').fill("30")
+        self.get_rows().nth(0).get_by_role("button", name="Clone row").click()
+
+        # 4. Verify cloning preserves the explicit value and does not replace it with the default.
+        self.assertEqual(self.get_column_values("age"), ["30", "42", "30"])
 
     def test_preview_icon_previews_and_opens_persisted_row(self):
         """

--- a/bloomerp/django_bloomerp/bloomerp/tests/widgets/test_one_to_many_field_widget.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/widgets/test_one_to_many_field_widget.py
@@ -62,6 +62,45 @@ class TestCreateView(BaseBloomerpModelTestCase):
             widget_html,
         )  # Ensure that a field not specified is not rendered.
 
+    def test_widget_renders_column_defaults_for_new_rows(self):
+        """
+        Use case: Render a one-to-many widget whose related model has a field default.
+        Expected result: The default is exposed as column metadata and fills missing rows.
+        """
+        # 1. Configure a default for the related model's age field.
+        model_field = self.CustomerModel._meta.get_field("age")
+        original_default = model_field.default
+        model_field.default = 42
+
+        try:
+            # 2. Render a prefilled row that omits the defaulted field.
+            widget = OneToManyFieldWidget(
+                attrs={
+                    "related_model": self.CustomerModel,
+                    "parent_model": self.CountryModel,
+                    "layout_config": {"inline_fields": ["first_name", "age"]},
+                }
+            )
+            soup = BeautifulSoup(
+                widget.render(
+                    name="customers",
+                    value=[{"first_name": "Draft customer"}],
+                    attrs={},
+                ),
+                "html.parser",
+            )
+
+            # 3. Verify both the column metadata and row/template inputs use the default.
+            age_column = soup.select_one('[data-one-to-many-column="age"]')
+            self.assertIsNotNone(age_column)
+            self.assertEqual(age_column["data-column-default-value"], "42")
+            age_inputs = soup.select(
+                '[data-one-to-many-cell="age"] input[name*="__age"]'
+            )
+            self.assertEqual([input_element.get("value") for input_element in age_inputs], ["42", "42"])
+        finally:
+            model_field.default = original_default
+
     def test_widget_collects_nested_rows_for_form_cleaning(self):
         widget = OneToManyFieldWidget()
         data = QueryDict(mutable=True)

--- a/bloomerp/django_bloomerp/bloomerp/widgets/one_to_many_field_widget.py
+++ b/bloomerp/django_bloomerp/bloomerp/widgets/one_to_many_field_widget.py
@@ -1,7 +1,9 @@
+import json
 from typing import TYPE_CHECKING
 from uuid import UUID
 
 from django.contrib.contenttypes.models import ContentType
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db import models
 from django.db.models import Model
 from django.forms import widgets
@@ -111,7 +113,16 @@ class OneToManyFieldWidget(widgets.Widget):
     def _should_skip_field(self, application_field) -> bool:
         return application_field.field in SKIPPED_FIELD_NAMES
 
-    def _render_cell_input(self, *, name, obj, application_field, attrs, row_index):
+    def _render_cell_input(
+        self,
+        *,
+        name,
+        obj,
+        application_field,
+        attrs,
+        row_index,
+        default_values=None,
+    ):
         cell_attrs = {
             "class": "one-to-many-field-widget__input input input-sm w-full border-0 bg-transparent px-2 py-1 shadow-none focus:bg-white",
         }
@@ -120,7 +131,11 @@ class OneToManyFieldWidget(widgets.Widget):
         if attrs and attrs.get("readonly"):
             cell_attrs["readonly"] = "readonly"
 
-        value = self._get_cell_value(obj=obj, application_field=application_field)
+        value = self._get_cell_value(
+            obj=obj,
+            application_field=application_field,
+            default_values=default_values,
+        )
         widget = application_field.get_widget()
         return widget.render(
             name=f"{name}__{row_index}__{application_field.field}",
@@ -128,14 +143,16 @@ class OneToManyFieldWidget(widgets.Widget):
             attrs=cell_attrs,
         )
 
-    def _get_cell_value(self, *, obj, application_field):
+    def _get_cell_value(self, *, obj, application_field, default_values=None):
         if obj is None:
-            return None
+            return (default_values or {}).get(application_field.field)
         if isinstance(obj, dict):
-            return obj.get(application_field.field)
+            if application_field.field in obj:
+                return obj[application_field.field]
+            return (default_values or {}).get(application_field.field)
         return getattr(obj, application_field.field, None)
 
-    def _build_cells(self, *, name, obj, columns, attrs, row_index):
+    def _build_cells(self, *, name, obj, columns, attrs, row_index, default_values=None):
         return [
             {
                 "column": column,
@@ -145,6 +162,7 @@ class OneToManyFieldWidget(widgets.Widget):
                     attrs=attrs,
                     name=name,
                     row_index=row_index,
+                    default_values=default_values,
                 ),
             }
             for column in columns
@@ -170,6 +188,9 @@ class OneToManyFieldWidget(widgets.Widget):
     def _build_column_context(
         self,
         application_field: "ApplicationField",
+        *,
+        has_default: bool,
+        default_value: object = None,
     ) -> dict[str, object]:
         """Build the metadata used by column actions, totals, and cell selectors."""
         kind = self._get_column_kind(application_field)
@@ -179,7 +200,37 @@ class OneToManyFieldWidget(widgets.Widget):
             "title": application_field.title,
             "kind": kind,
             "show_total": bool(self.layout_config.get("show_totals")) and kind == "number",
+            "default_value_json": (
+                self._serialize_default_value(default_value) if has_default else ""
+            ),
         }
+
+    @staticmethod
+    def _get_column_default(application_field: "ApplicationField") -> tuple[bool, object]:
+        """Return a related model field's default in widget-ready form."""
+        try:
+            model_field = application_field._get_model_field()
+        except Exception:
+            return False, None
+        if not model_field.has_default():
+            return False, None
+
+        try:
+            default_value = model_field.get_default()
+            form_field = application_field.get_form_field()
+            if form_field is not None:
+                default_value = form_field.prepare_value(default_value)
+            return True, default_value
+        except Exception:
+            return True, None
+
+    @staticmethod
+    def _serialize_default_value(value: object) -> str:
+        """Serialize a column default for the frontend data attribute."""
+        try:
+            return json.dumps(value, cls=DjangoJSONEncoder)
+        except (TypeError, ValueError):
+            return json.dumps(str(value))
     
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
@@ -195,6 +246,20 @@ class OneToManyFieldWidget(widgets.Widget):
             context['detail_url_template'] = ""
         
         columns = self.get_columns()
+        column_defaults = {}
+        column_context = []
+        for column in columns:
+            has_default, default_value = self._get_column_default(column)
+            if has_default:
+                column_defaults[column.field] = default_value
+            column_context.append(
+                self._build_column_context(
+                    column,
+                    has_default=has_default,
+                    default_value=default_value,
+                )
+            )
+
         related_objects = self._get_related_objects(value)
         rows = []
         for row_index, obj in enumerate(related_objects):
@@ -210,12 +275,13 @@ class OneToManyFieldWidget(widgets.Widget):
                         columns=columns,
                         attrs=attrs,
                         row_index=row_index,
+                        default_values=column_defaults,
                     ),
                 }
             )
 
         context['related_objects'] = related_objects
-        context['columns'] = [self._build_column_context(column) for column in columns]
+        context['columns'] = column_context
         context['rows'] = rows
         context['empty_row'] = {
             "id": "",
@@ -227,6 +293,7 @@ class OneToManyFieldWidget(widgets.Widget):
                 columns=columns,
                 attrs=attrs,
                 row_index="__prefix__",
+                default_values=column_defaults,
             ),
         }
         context['can_edit'] = not attrs.get("disabled")

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.12.0beta24"
+version = "1.12.0beta25"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/bloomerp/django_bloomerp/uv.lock
+++ b/bloomerp/django_bloomerp/uv.lock
@@ -232,7 +232,7 @@ wheels = [
 
 [[package]]
 name = "bloomerp"
-version = "1.12.0b23"
+version = "1.12.0b25"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
## To-do

- ID: `a4b28e19-8f8a-468c-b54b-36af63eeb731`
- Title: `[BUG] One-to-many field does not respect default values when adding/prefilling rows`

## Summary

- Expose normalized related-model field defaults as one-to-many column metadata.
- Apply those defaults when rendering missing prefilled values and when adding or behavior-populating rows.
- Preserve explicit row values when cloning or replacing rows.
- Add focused widget and E2E regression coverage.
- Bump the package version to `1.12.0beta25`.

## Root cause

The one-to-many row template rendered each related column with `None`, so cloned template rows started blank even when the related Django model field defined a default.

## Validation

- `uv run pytest bloomerp/tests/widgets/test_one_to_many_field_widget.py` — 5 passed.
- `npm run type-check` — passed.
- `uv run pytest bloomerp/tests/e2e/widgets/test_one_to_many_widget_e2e.py::TestOneToManyWidgetE2E::test_add_and_clone_rows_use_column_defaults` — passed.
- `uv run pytest bloomerp/tests/e2e/generic/test_field_behavior_e2e.py::TestFieldBehaviorE2E::test_populate_related_rows_uses_column_defaults` — passed.
- Full one-to-many and field-behavior E2E modules — 20 passed.
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache uv lock --check` — passed.
- Python compilation check for changed Python files — passed.

The pre-existing change to `bloomerp/django_bloomerp/bloomerp/static/bloomerp/css/dist/styles.css` was intentionally left unstaged and outside this PR.
