### PR TITLE
Add create or update automation trigger

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/automation/defintion.py
+++ b/bloomerp/django_bloomerp/bloomerp/automation/defintion.py
@@ -67,6 +67,13 @@ class WorkflowNodeType(Enum):
                 executor_cls=ObjectCrudTrigger,
                 icon="fa-solid fa-pen-to-square"
             ),
+            NodeSubTypeDefinition(
+                id="ON_OBJECT_CREATE_OR_UPDATE",
+                name="On Object Create or Update",
+                description="Triggered when an object is created or updated",
+                executor_cls=ObjectCrudTrigger,
+                icon="fa-solid fa-arrows-rotate"
+            ),
             NodeSubTypeDefinition( 
                 id="ON_OBJECT_DELETE",
                 name="On Object Deletion",

--- a/bloomerp/django_bloomerp/bloomerp/signals/automation_signals.py
+++ b/bloomerp/django_bloomerp/bloomerp/signals/automation_signals.py
@@ -235,8 +235,13 @@ def setup_automation_signals(refresh: bool = False) -> None:
 	if _SIGNALS_INITIALIZED and refresh:
 		_disconnect_registered_handlers()
 
-	create_triggers = WorkflowNode.get_triggers_by_type("ON_OBJECT_CREATE")
-	update_triggers = WorkflowNode.get_triggers_by_type("ON_OBJECT_UPDATE")
+	create_triggers = list(WorkflowNode.get_triggers_by_type("ON_OBJECT_CREATE"))
+	update_triggers = list(WorkflowNode.get_triggers_by_type("ON_OBJECT_UPDATE"))
+	create_or_update_triggers = list(
+		WorkflowNode.get_triggers_by_type("ON_OBJECT_CREATE_OR_UPDATE")
+	)
+	create_triggers.extend(create_or_update_triggers)
+	update_triggers.extend(create_or_update_triggers)
 	delete_triggers = WorkflowNode.get_triggers_by_type("ON_OBJECT_DELETE")
 
 	trigger_sets = {

--- a/bloomerp/django_bloomerp/bloomerp/tests/automation/test_automation.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/automation/test_automation.py
@@ -602,6 +602,52 @@ class TestAutomation(TransactionTestCase):
 
             run_workflow_mock.assert_called_once()
 
+    def test_run_workflow_called_after_create_or_update(self):
+        """
+        Use case: A workflow has a combined object create-or-update trigger.
+        Expected result: The workflow runs once for both a create and an update.
+        """
+        # 1. Create a workflow with a combined post-save trigger.
+        content_type = ContentType.objects.get_for_model(self.CustomerModel)
+        workflow = Workflow.objects.create(
+            name="Create Or Update Trigger Workflow",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        WorkflowNode.objects.create(
+            workflow=workflow,
+            config={
+                "sub_type": "ON_OBJECT_CREATE_OR_UPDATE",
+                "parameters": {"content_type_id": content_type.id},
+            },
+            type=WorkflowNodeType.TRIGGER.value.id,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        setup_automation_signals(refresh=True)
+
+        # 2. Verify the combined trigger handles object creation.
+        with patch("bloomerp.signals.automation_signals.run_workflow") as run_workflow_mock:
+            instance = self.CustomerModel.objects.create(
+                first_name="Create",
+                last_name="Or Update",
+                age=30,
+                created_by=self.user,
+                updated_by=self.user,
+            )
+
+            run_workflow_mock.assert_called_once()
+            self.assertEqual(run_workflow_mock.call_args.args[1]["event"], "create")
+
+        # 3. Verify the same trigger handles object updates.
+        with patch("bloomerp.signals.automation_signals.run_workflow") as run_workflow_mock:
+            instance.age = 31
+            instance.updated_by = self.user
+            instance.save()
+
+            run_workflow_mock.assert_called_once()
+            self.assertEqual(run_workflow_mock.call_args.args[1]["event"], "update")
+
     def test_inactive_workflow_does_not_run_after_create(self):
         """
         Use case: An inactive workflow has an object-create trigger.


### PR DESCRIPTION
## To-do
`todo/5aa9-add-on-create-or-update-trigger`

## Summary
- Add the `ON_OBJECT_CREATE_OR_UPDATE` workflow trigger subtype.
- Register combined triggers for both object creation and update post-save signals.
- Add a regression test covering both event payloads.

## Verification
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.automation.test_automation.TestAutomation.test_run_workflow_called_after_create_or_update` — passed (1 test).
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python -m py_compile bloomerp/automation/defintion.py bloomerp/signals/automation_signals.py bloomerp/tests/automation/test_automation.py` — passed.
- Full automation module: 59 tests, 11 pre-existing failures and 2 pre-existing errors in unrelated action/condition/merge coverage; the new test passed.
- `git diff --check` — passed.

The to-do API could not be updated because `BLOOMERP_TODO_API_KEY` was unavailable.