### PR TITLE
Fix light-mode checkbox styling

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static/bloomerp/css/dist/styles.css
+++ b/bloomerp/django_bloomerp/bloomerp/static/bloomerp/css/dist/styles.css
@@ -3953,7 +3953,7 @@
     border-color: var(--color-zinc-700);
     color: var(--color-zinc-100);
   }
-  .dark .input, .dark .select, .dark .node-input, .dark .node-select {
+  .dark .input:not([type='checkbox']):not([type='radio']), .dark .select, .dark .node-input, .dark .node-select {
     background-color: var(--color-zinc-800);
     border-color: var(--color-zinc-600);
     color: var(--color-zinc-100);
@@ -4808,7 +4808,7 @@
   }
 }
 @layer utilities {
-  .input {
+  .input:not([type='checkbox']):not([type='radio']) {
     border-radius: var(--radius-xl);
     border-style: var(--tw-border-style);
     border-width: 1px;
@@ -4829,17 +4829,17 @@
       --tw-ring-color: var(--color-primary);
     }
   }
-  .input-sm {
+  .input-sm:not([type='checkbox']):not([type='radio']) {
     padding-inline: calc(var(--spacing) * 2);
     padding-block: calc(var(--spacing) * 1);
     font-size: var(--text-xs);
     line-height: var(--tw-leading, var(--text-xs--line-height));
   }
-  .input-lg {
+  .input-lg:not([type='checkbox']):not([type='radio']) {
     padding-inline: calc(var(--spacing) * 4);
     padding-block: calc(var(--spacing) * 3);
   }
-  .input:disabled {
+  .input:disabled:not([type='checkbox']):not([type='radio']) {
     cursor: not-allowed;
     background-color: var(--color-gray-100);
   }

--- a/bloomerp/django_bloomerp/bloomerp/static_src/src/styles.css
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/src/styles.css
@@ -195,7 +195,7 @@
     color: var(--color-zinc-100);
   }
 
-  .dark .input,
+  .dark .input:not([type='checkbox']):not([type='radio']),
   .dark .select,
   .dark .node-input,
   .dark .node-select {
@@ -895,20 +895,20 @@
 */
 @layer utilities {
     /*Default utilities*/
-    .input {
+    .input:not([type='checkbox']):not([type='radio']) {
       @apply px-3 py-2 text-sm border border-gray-200 rounded-xl focus:ring-1 focus:ring-primary focus:border-primary bg-white
     }
 
     /* Input size variants */
-    .input-sm {
+    .input-sm:not([type='checkbox']):not([type='radio']) {
       @apply px-2 py-1 text-xs
     }
 
-    .input-lg {
+    .input-lg:not([type='checkbox']):not([type='radio']) {
       @apply px-4 py-3 
     }
 
-    .input:disabled {
+    .input:disabled:not([type='checkbox']):not([type='radio']) {
       @apply bg-gray-100 cursor-not-allowed
     }
 


### PR DESCRIPTION
## To-do

`0a136b37-d216-4f15-b954-288fef221576` — [BUG] Checkbox styling in light mode doesn't show anymore because

## What changed

The shared `.input` utility no longer applies form-control spacing, background, border, radius, disabled, or dark-theme styling to checkbox and radio inputs. This restores the checkbox component's own visible light-mode styling while preserving the existing appearance of text inputs, selects, textareas, and other `.input` consumers.

## Validation

- `npm exec -- tailwindcss --postcss -i ./src/styles.css -o /private/tmp/bloomerp-todo-1576-styles.css`
- Verified the generated CSS contains the checkbox/radio exclusions for both the shared input utility and dark-theme compatibility rules.
- `git diff --check`

No automated browser test was added because this is a CSS-only visual regression; the Tailwind build and generated-selector assertions provide focused validation.
