### PR TITLE
[BUG] Fix text editors in one-to-many rows

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/OneToManyFieldWidget.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/OneToManyFieldWidget.ts
@@ -282,7 +282,7 @@ export default class OneToManyFieldWidget extends BaseWidget {
     }
 
     private replacePrefix(root: ParentNode, rowIndex: number): void {
-        const elements = root.querySelectorAll<HTMLElement>("[name], [id], [for], [data-field-name]");
+        const elements = root.querySelectorAll<HTMLElement>("*");
         elements.forEach((element) => {
             for (const attr of ["name", "id", "for"]) {
                 const value = element.getAttribute(attr);

--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/ui/inputs/text_editor.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/ui/inputs/text_editor.html
@@ -1,5 +1,6 @@
 {% load bloomerp %}
 {% generate_uuid as editor_uuid %}
+{% with editor_id=editor_uuid|add:"-"|add:name %}
 
 <div 
     bloomerp-component="bloomerp-text-editor" 
@@ -10,17 +11,18 @@
     data-override-default-styling="{{ override_default_styling|default:'False'}}"
     data-name="{{ name }}"
     data-actions-toolbar-section-id="{{ actions_toolbar_section_id }}"
-    data-editor-id="{{ editor_uuid }}"
+    data-editor-id="{{ editor_id }}"
     data-include-toolbar="{{ include_toolbar }}"
     {% if height %}style="height: {{ height }};"{% endif %}
     >
-    <style id="text-editor-styling-{{ editor_uuid }}"></style>
+    <style id="text-editor-styling-{{ editor_id }}"></style>
 
     <!--Toolbar-->
     {% if include_toolbar != False and include_toolbar != "false" and include_toolbar != "False" %}
-    <div class="" id="actions-toolbar-{{ editor_uuid }}"></div>
+    <div class="" id="actions-toolbar-{{ editor_id }}"></div>
     {% endif %}
     <!--End toolbar-->
-    <div id="editor-{{ editor_uuid }}" class="outline-none bloomerp-text-editor" contenteditable></div>
+    <div id="editor-{{ editor_id }}" class="outline-none bloomerp-text-editor" contenteditable></div>
     <input type="hidden" data-text-editor-input="true" name="{{ name }}" value="{{ value }}" id="id_{{ name }}">
 </div>
+{% endwith %}

--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/ui/inputs/text_editor.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/ui/inputs/text_editor.html
@@ -4,7 +4,7 @@
 
 <div 
     bloomerp-component="bloomerp-text-editor" 
-    class="relative rounded-xl {% if not height %}min-h-72{% endif %} {% if has_border %}border border-gray-300 {% if not disabled %}focus-within:border-primary focus-within:ring-1 focus-within:ring-primary{% endif %}{% endif %} {% if disabled %}bg-gray-100 cursor-not-allowed{% endif %} {{ class|default:'' }}" 
+    class="relative rounded-xl {% if not height %}{% if compact %}min-h-36{% else %}min-h-72{% endif %}{% endif %} {% if has_border %}border border-gray-300 {% if not disabled %}focus-within:border-primary focus-within:ring-1 focus-within:ring-primary{% endif %}{% endif %} {% if disabled %}bg-gray-100 cursor-not-allowed{% endif %} {{ class|default:'' }}"
     data-placeholder="{{ placeholder|default:'' }}"
     data-disabled="{{ disabled|yesno:'true,false' }}"
     data-styling="{{ styling|default:'' }}"

--- a/bloomerp/django_bloomerp/bloomerp/tests/base.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/base.py
@@ -11,6 +11,7 @@ import re
 import tempfile
 from bloomerp.management.commands import save_application_fields
 from bloomerp.model_fields.file_field import BloomerpFileField
+from bloomerp.model_fields.text_editor_field import TextEditorField
 from bloomerp.tests.utils.users import create_admin, create_normal_user
 from bloomerp.tests.utils.dynamic_models import create_test_models
 from bloomerp.tests.utils.names import FIRST_NAMES, LAST_NAMES
@@ -57,6 +58,7 @@ class BaseBloomerpModelTestCase(TransactionTestCase):
             "age" : models.IntegerField(max_length=3),
             "picture" : BloomerpFileField(blank=True, null=True),
             "date_joined" : models.DateField(blank=True, null=True),
+            "description": TextEditorField(blank=True, null=True),
             "__str__" : lambda self: f"{self.first_name} {self.last_name}"
         }
         

--- a/bloomerp/django_bloomerp/bloomerp/tests/e2e/widgets/test_one_to_many_widget_e2e.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/e2e/widgets/test_one_to_many_widget_e2e.py
@@ -17,7 +17,13 @@ from bloomerp.utils.models import get_create_view_url
 
 class TestOneToManyWidgetE2E(TestCrudE2EMixin, BaseE2ETestCase):
     create_foreign_models = True
-    inline_fields = ["first_name", "customer_type", "age", "date_joined"]
+    inline_fields = [
+        "first_name",
+        "customer_type",
+        "age",
+        "date_joined",
+        "description",
+    ]
 
     def extendedE2ESetup(self) -> None:
         """Expose Country.customers as an editable one-to-many test widget."""
@@ -178,6 +184,40 @@ class TestOneToManyWidgetE2E(TestCrudE2EMixin, BaseE2ETestCase):
 
         # 4. Verify cloning preserves the explicit value and does not replace it with the default.
         self.assertEqual(self.get_column_values("age"), ["30", "42", "30"])
+
+    def test_text_editors_update_their_own_one_to_many_rows(self):
+        """
+        Use case: Edit text-editor fields in two newly added one-to-many rows.
+        Expected result: Each editor updates only the hidden input in its own row.
+        """
+        # 1. Open an empty country form and add two customer rows.
+        self.goto(self.get_base_url())
+        add_row_button = self.get_widget().get_by_role("button", name="Add row")
+        add_row_button.click()
+        add_row_button.click()
+        expect(self.get_rows()).to_have_count(2)
+
+        # 2. Enter different content in each row's text editor.
+        first_editor = self.get_rows().nth(0).locator(
+            '[data-one-to-many-cell="description"] .bloomerp-text-editor'
+        )
+        second_editor = self.get_rows().nth(1).locator(
+            '[data-one-to-many-cell="description"] .bloomerp-text-editor'
+        )
+        first_editor.fill("First customer description")
+        second_editor.fill("Second customer description")
+
+        # 3. Verify each editor synchronized its own row's form input.
+        first_value = self.get_rows().nth(0).locator(
+            '[data-one-to-many-cell="description"] [data-text-editor-input="true"]'
+        ).input_value()
+        second_value = self.get_rows().nth(1).locator(
+            '[data-one-to-many-cell="description"] [data-text-editor-input="true"]'
+        ).input_value()
+        self.assertIn("First customer description", first_value)
+        self.assertNotIn("Second customer description", first_value)
+        self.assertIn("Second customer description", second_value)
+        self.assertNotIn("First customer description", second_value)
 
     def test_preview_icon_previews_and_opens_persisted_row(self):
         """

--- a/bloomerp/django_bloomerp/bloomerp/tests/widgets/test_one_to_many_field_widget.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/widgets/test_one_to_many_field_widget.py
@@ -101,6 +101,32 @@ class TestCreateView(BaseBloomerpModelTestCase):
         finally:
             model_field.default = original_default
 
+    def test_widget_renders_text_editors_with_compact_height(self):
+        """
+        Use case: Render a text editor as an inline one-to-many column.
+        Expected result: The inline editor is shorter than a standalone editor.
+        """
+        # 1. Render the optional customer description as an inline column.
+        widget = OneToManyFieldWidget(
+            attrs={
+                "related_model": self.CustomerModel,
+                "parent_model": self.CountryModel,
+                "layout_config": {"inline_fields": ["description"]},
+            }
+        )
+        soup = BeautifulSoup(
+            widget.render(name="customers", value=None, attrs={}),
+            "html.parser",
+        )
+
+        # 2. Verify the row template's editor uses only the compact minimum height.
+        editor = soup.select_one(
+            '[data-one-to-many-row-template] [bloomerp-component="bloomerp-text-editor"]'
+        )
+        self.assertIsNotNone(editor)
+        self.assertIn("min-h-36", editor.get("class", []))
+        self.assertNotIn("min-h-72", editor.get("class", []))
+
     def test_widget_collects_nested_rows_for_form_cleaning(self):
         widget = OneToManyFieldWidget()
         data = QueryDict(mutable=True)

--- a/bloomerp/django_bloomerp/bloomerp/widgets/text_editor.py
+++ b/bloomerp/django_bloomerp/bloomerp/widgets/text_editor.py
@@ -8,11 +8,13 @@ class BloomerpTextEditorWidget(forms.Textarea):
         attrs.setdefault('id', 'id_%s' % name)
         context = super().get_context(name, value, attrs)
         widget_context = context.get('widget', {})
+        widget_classes = widget_context.get('attrs', {}).get('class', '').split()
         new_context = {**widget_context.get('attrs', {})}
         new_context.update({
             'name': widget_context.get('name'),
             'value': widget_context.get('value'),
             'disabled': widget_context.get('attrs', {}).get('disabled', False),
-            'include_toolbar' : True
+            'include_toolbar' : True,
+            'compact': 'one-to-many-field-widget__input' in widget_classes,
         })
         return new_context

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.12.0beta26"
+version = "1.12.0beta27"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## To-do

- ID: `65c13221-add2-4d18-8471-078dc27b8ee5`
- Title: **[BUG] Text editor when shown in one-to-many only allows updating the first occurence**

## Summary

- Include the row-prefixed form field name in each text editor's DOM identity.
- Replace `__prefix__` placeholders across every cloned element's data attributes so editor IDs, toolbars, and styling targets remain unique per one-to-many row.
- Render text editors embedded in one-to-many rows with `min-h-36`, while standalone editors retain `min-h-72`.
- Add an optional text-editor description field to the dynamic customer fixture and browser coverage for independently editing two new customer rows.
- Add rendering coverage for the compact inline height.

## Root cause

One-to-many rows are cloned from a shared template. The text editor's generated UUID was reused by every clone, while its row prefix was not part of the editor ID and was not substituted on the component's data attributes. Later editor instances could therefore resolve ID-based editor elements against the first row.

## Validation

- `npm run type-check` — passed
- `npm run build` — passed
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.e2e.widgets.test_one_to_many_widget_e2e` — 14 passed before the sizing-only follow-up
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.widgets.test_one_to_many_field_widget` — 6 passed after the sizing follow-up
- Focused E2E rerun after the sizing follow-up — blocked twice before editor interaction by the existing hidden `field-display-option-modal` intercepting the Add row click

The existing project/model warnings and dynamic-model registration warnings remain unchanged.