### PR TITLE
[FILTERS] Add "Not Equals" filter for foreign fields

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/field_types/lookups.py
+++ b/bloomerp/django_bloomerp/bloomerp/field_types/lookups.py
@@ -79,7 +79,7 @@ def _equals_widget(application_field: "ApplicationField") -> forms.Widget:
     match application_field.field_type_enum:
         case FieldType.BOOLEAN_FIELD:
             return forms.Select(choices=[("true", "True"), ("false", "False")], attrs={"class": "select w-full"})
-        case FieldType.FOREIGN_KEY:
+        case FieldType.FOREIGN_KEY | FieldType.ONE_TO_ONE_FIELD:
             return ForeignFieldWidget(model=application_field.related_model.model_class(), attrs={"class": "input w-full"})
         case FieldType.MANY_TO_MANY_FIELD:
             return ForeignFieldWidget(model=application_field.related_model.model_class(), attrs={"class": "input w-full", "is_m2m": True})
@@ -230,6 +230,9 @@ def _simple_filter_classes(
 
 
 def _not_equals_filter_class(application_field: "ApplicationField", lookup: "LookupDefinition") -> dict[str, django_filters.Filter]:
+    if _is_relation_choice_field(application_field):
+        return _relation_filter_class(application_field, lookup, exclude=True)
+
     def filter_not_equal(queryset: QuerySet, name: str, value):
         if value in django_filters.constants.EMPTY_VALUES:
             return queryset
@@ -257,7 +260,12 @@ def _relative_date_filter_class(application_field: "ApplicationField", lookup: "
     }
 
 
-def _relation_filter_class(application_field: "ApplicationField", lookup: "LookupDefinition") -> dict[str, django_filters.Filter]:
+def _relation_filter_class(
+    application_field: "ApplicationField",
+    lookup: "LookupDefinition",
+    *,
+    exclude: bool = False,
+) -> dict[str, django_filters.Filter]:
     related_model = application_field.get_related_model()
     if related_model is None:
         return {}
@@ -268,13 +276,18 @@ def _relation_filter_class(application_field: "ApplicationField", lookup: "Looku
             "queryset": related_model.objects.all(),
             "to_field_name": "id",
             "distinct": True,
+            "exclude": exclude,
         }
     elif lookup.id == "in":
         filter_cls = django_filters.ModelMultipleChoiceFilter
-        kwargs = {"queryset": related_model.objects.all(), "widget": django_filters.widgets.CSVWidget}
+        kwargs = {
+            "queryset": related_model.objects.all(),
+            "widget": django_filters.widgets.CSVWidget,
+            "exclude": exclude,
+        }
     else:
         filter_cls = django_filters.ModelChoiceFilter
-        kwargs = {"queryset": related_model.objects.all()}
+        kwargs = {"queryset": related_model.objects.all(), "exclude": exclude}
 
     return {
         name: filter_cls(field_name=application_field.field, **kwargs)

--- a/bloomerp/django_bloomerp/bloomerp/field_types/types.py
+++ b/bloomerp/django_bloomerp/bloomerp/field_types/types.py
@@ -673,6 +673,7 @@ class FieldType(Enum):
         model_field_cls=models.ForeignKey,
         lookups=[
             Lookup.EQUALS,
+            Lookup.NOT_EQUALS,
             Lookup.IN,
             Lookup.FOREIGN_ADVANCED,
             Lookup.IS_NULL,
@@ -700,6 +701,7 @@ class FieldType(Enum):
         lookups=[
             Lookup.IS_NULL,
             Lookup.EQUALS,
+            Lookup.NOT_EQUALS,
             Lookup.IN,
         ],
         default_model_field_args={
@@ -720,6 +722,7 @@ class FieldType(Enum):
         model_field_cls=models.ManyToManyField,
         lookups=[
             Lookup.EQUALS,
+            Lookup.NOT_EQUALS,
             Lookup.IS_NULL,
             Lookup.IN,
         ],

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/Filters.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/Filters.ts
@@ -8,6 +8,8 @@ import { formatFilterLabel, formatFilterTooltip } from "@/utils/filterLabels";
 export const LOOKUP_LABELS : Map<string, string> = new Map([
     ["exact", "is"],
     ["equals", "is"],
+    ["not_equals", "is not"],
+    ["ne", "is not"],
     ["icontains", "contains"],
     ["contains", "contains"],
     ["startswith", "starts with"],

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/utils/filterLabels.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/utils/filterLabels.ts
@@ -1,6 +1,8 @@
 const LOOKUP_LABELS: Record<string, string> = {
     exact: "is",
     equals: "is",
+    not_equals: "is not",
+    ne: "is not",
     icontains: "contains",
     contains: "contains",
     startswith: "starts with",

--- a/bloomerp/django_bloomerp/bloomerp/tests/bloomerp_utils/filters.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/bloomerp_utils/filters.py
@@ -47,6 +47,13 @@ class TestFilterUtil(BaseBloomerpModelTestCase):
                         blank=True,
                         related_name="primary_records",
                     ),
+                    "one_to_one_field": models.OneToOneField(
+                        "FilterTag",
+                        on_delete=models.SET_NULL,
+                        null=True,
+                        blank=True,
+                        related_name="one_to_one_primary_record",
+                    ),
                     "many_to_many_field": models.ManyToManyField(
                         "FilterTag",
                         blank=True,
@@ -121,6 +128,7 @@ class TestFilterUtil(BaseBloomerpModelTestCase):
             "uuid_field": FieldType.UUID_FIELD,
             "week_field": FieldType.WEEK_FIELD,
             "foreign_key_field": FieldType.FOREIGN_KEY,
+            "one_to_one_field": FieldType.ONE_TO_ONE_FIELD,
             "many_to_many_field": FieldType.MANY_TO_MANY_FIELD,
             "lines": FieldType.ONE_TO_MANY_FIELD,
         }
@@ -239,6 +247,36 @@ class TestFilterUtil(BaseBloomerpModelTestCase):
         self.assert_filtered_ids({"many_to_many_field__equals": [str(frontend.id)]}, [frontend_record.id, both_record.id])
         self.assert_filtered_ids({"many_to_many_field__in": [str(backend.id)]}, [backend_record.id, both_record.id])
         self.assert_filtered_ids({"many_to_many_field__name__icontains": "front"}, [frontend_record.id, both_record.id])
+
+    def test_not_equals_filters_exclude_selected_foreign_relations(self):
+        """
+        Use case: A user filters FK, O2O, and M2M fields with Not Equals.
+        Expected result: Records related to the selected values are excluded for every relation type.
+        """
+        # 1. Create relation values and records covering selected, other, empty, and overlapping relations.
+        backend = self.TagModel.objects.create(name="Backend")
+        frontend = self.TagModel.objects.create(name="Frontend")
+        selected_record = self.create_primary(foreign_key_field=backend, one_to_one_field=backend)
+        selected_record.many_to_many_field.add(backend)
+        other_record = self.create_primary(foreign_key_field=frontend, one_to_one_field=frontend)
+        other_record.many_to_many_field.add(frontend)
+        empty_record = self.create_primary(foreign_key_field=None, one_to_one_field=None)
+        overlapping_record = self.create_primary(foreign_key_field=backend)
+        overlapping_record.many_to_many_field.add(backend, frontend)
+
+        # 2. Exclude the selected value through both supported Not Equals aliases.
+        self.assert_filtered_ids(
+            {"foreign_key_field__not_equals": str(backend.id)},
+            [other_record.id, empty_record.id],
+        )
+        self.assert_filtered_ids(
+            {"one_to_one_field__ne": str(backend.id)},
+            [other_record.id, empty_record.id, overlapping_record.id],
+        )
+        self.assert_filtered_ids(
+            {"many_to_many_field__not_equals": [str(backend.id)]},
+            [other_record.id, empty_record.id],
+        )
 
     def test_one_to_many_count_filters_use_declared_aliases(self):
         no_lines = self.create_primary()

--- a/bloomerp/django_bloomerp/bloomerp/tests/components/filters.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/components/filters.py
@@ -139,6 +139,26 @@ class TestFilterComponent(BaseBloomerpModelTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'value="is_null"', html=False)
 
+    def test_lookup_operators_include_not_equals_for_foreign_key_fields(self):
+        """
+        Use case: A user selects an operator for a foreign-key filter.
+        Expected result: Not Equals is available as a relation filter operator.
+        """
+        # 1. Request the lookup operators for a foreign-key application field.
+        application_field = ApplicationField.get_by_field(self.CustomerModel, "country")
+        url = reverse(
+            "components_filters_lookup_operators",
+            kwargs={
+                "content_type_id": application_field.content_type_id,
+                "application_field_id": application_field.id,
+            },
+        )
+        response = self.client.get(url)
+
+        # 2. Verify the new relation operator is exposed by the filter UI.
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'value="not_equals"', html=False)
+
     def test_lookup_operators_include_relative_date_options_for_date_fields(self):
         application_field = ApplicationField.get_by_field(self.EventModel, "starts_on")
         url = reverse(


### PR DESCRIPTION
## To-do

- ID: `fd5832f8-631c-4108-a9d5-bdfb3c7be968`
- Title: **[FILTERS] Add new "not equals" filter for foreign fields (FK, M2M, O2O)**

## Summary

- Expose the existing Not Equals lookup for foreign-key, many-to-many, and one-to-one fields.
- Use relation-aware choice filters with exclusion semantics and distinct M2M results.
- Render the correct foreign-field selector for one-to-one values.
- Add readable frontend labels for `not_equals` and `ne`.
- Add focused backend and component tests covering relation exclusion and UI operator availability.

## Impact

Users can filter out records associated with selected FK, M2M, or O2O values. Empty relations remain included, while M2M records containing any selected excluded value are removed without duplicate results.

## Validation

Passed:

- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.bloomerp_utils.filters bloomerp.tests.components.filters.TestFilterComponent.test_lookup_operators_include_not_equals_for_foreign_key_fields` — 13 tests passed.
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py check` — no issues.
- `npm run build` — production TypeScript/Tailwind build passed.
- `git diff --check` — passed.

A broader run of both complete filter test modules found 9 failures in existing component date/widget expectations unrelated to this change (4 errors and 5 failures). The focused changed behavior and the complete filter utility module pass.