### PR TITLE
feat: add global text editor toolbar toggle

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/src/styles.css
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/src/styles.css
@@ -1364,6 +1364,39 @@ Dashboard
 }
 
 /*
+  Text editor toolbar visibility
+*/
+
+[data-text-editor-toolbar] {
+  max-height: 100rem;
+  opacity: 1;
+  transition: max-height 220ms ease, opacity 180ms ease, margin-bottom 220ms ease;
+}
+
+[data-text-editor-toolbar][data-toolbar-hidden="true"] {
+  max-height: 0;
+  margin-bottom: 0 !important;
+  opacity: 0;
+  overflow: hidden !important;
+  pointer-events: none;
+}
+
+[data-text-editor-toolbar-reveal] {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 10;
+  opacity: 0.2;
+  transition: opacity 180ms ease, transform 180ms ease;
+}
+
+[data-text-editor-toolbar-reveal]:hover,
+[data-text-editor-toolbar-reveal]:focus-visible {
+  opacity: 1;
+  transform: scale(1.05);
+}
+
+/*
   Legend
 */
 

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/text_editor/BloomerpTextEditor.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/text_editor/BloomerpTextEditor.ts
@@ -44,6 +44,11 @@ import { BaseWidget } from "../widgets/BaseWidget";
 import { parseBoolean } from "../../utils/booleans";
 
 import HtmlNode from "./nodes/HtmlNode";
+import {
+    createToolbarVisibilityCookie,
+    isToolbarHiddenFromCookie,
+    TEXT_EDITOR_TOOLBAR_VISIBILITY_EVENT,
+} from "./utils/toolbarVisibility";
 
 
 export class BloomerpTextEditor extends BaseWidget {
@@ -53,6 +58,10 @@ export class BloomerpTextEditor extends BaseWidget {
     private actions: Array<Action> = [];
     
     private actionsToolbar: HTMLElement | null = null;
+    private toolbarToggleButton: HTMLButtonElement | null = null;
+    private toolbarRevealButton: HTMLButtonElement | null = null;
+    private toolbarHidden: boolean = false;
+    private toolbarVisibilityHandler: ((event: Event) => void) | null = null;
     private hiddenInput:HTMLInputElement;
     private suppressNextChange: boolean = false;
     private isInitializing: boolean = false;
@@ -127,6 +136,19 @@ export class BloomerpTextEditor extends BaseWidget {
             },
         });
         this.includeToolbar = parseBoolean(this.element.dataset.includeToolbar, true);
+        this.toolbarHidden = isToolbarHiddenFromCookie(document.cookie);
+        this.toolbarVisibilityHandler = (event: Event) => {
+            const customEvent = event as CustomEvent<{ hidden?: boolean }>;
+            const hidden = customEvent.detail?.hidden;
+
+            this.setToolbarHidden(
+                typeof hidden === "boolean"
+                    ? hidden
+                    : isToolbarHiddenFromCookie(document.cookie),
+                false,
+            );
+        };
+        window.addEventListener(TEXT_EDITOR_TOOLBAR_VISIBILITY_EVENT, this.toolbarVisibilityHandler);
 
         this.editor.setRootElement(editorRef);
         this.isInitializing = true;
@@ -166,6 +188,14 @@ export class BloomerpTextEditor extends BaseWidget {
     }
 
     public destroy(): void {
+        if (this.toolbarVisibilityHandler) {
+            window.removeEventListener(
+                TEXT_EDITOR_TOOLBAR_VISIBILITY_EVENT,
+                this.toolbarVisibilityHandler,
+            );
+            this.toolbarVisibilityHandler = null;
+        }
+
         this.unregister?.();
         this.unregister = null;
 
@@ -176,6 +206,10 @@ export class BloomerpTextEditor extends BaseWidget {
             this.actionsToolbar.innerHTML = ''
             this.actionsToolbar = null;
         }
+
+        this.toolbarToggleButton = null;
+        this.toolbarRevealButton?.remove();
+        this.toolbarRevealButton = null;
     }
 
     /**
@@ -202,6 +236,7 @@ export class BloomerpTextEditor extends BaseWidget {
         this.actionsToolbar = document.getElementById(actionsToolbarId) as HTMLElement | null;
         if (!this.actionsToolbar) return;
 
+        this.toolbarToggleButton = null;
         this.actionsToolbar.innerHTML = ''
 
 
@@ -226,6 +261,73 @@ export class BloomerpTextEditor extends BaseWidget {
         if (standardToolbar) {
             this.actionsToolbar.className = 'flex mb-4 gap-2 overflow-x-scroll'
         }
+
+        this.actionsToolbar.dataset.textEditorToolbar = 'true';
+        this.createToolbarToggleButton();
+        this.createToolbarRevealButton();
+        this.setToolbarHidden(this.toolbarHidden, false);
+    }
+
+    private createToolbarToggleButton(): void {
+        if (!this.actionsToolbar) return;
+
+        const toggleButton = document.createElement('button');
+        toggleButton.type = 'button';
+        toggleButton.className = 'btn btn-secondary btn-sm shrink-0';
+        toggleButton.setAttribute('aria-label', 'Hide formatting toolbar');
+        toggleButton.title = 'Hide formatting toolbar';
+        toggleButton.innerHTML = '<i class="fa-solid fa-eye-slash" aria-hidden="true"></i><span class="sr-only">Hide formatting toolbar</span>';
+        toggleButton.addEventListener('mousedown', (event) => {
+            event.preventDefault();
+        });
+        toggleButton.addEventListener('click', () => {
+            this.setToolbarHidden(true, true);
+        });
+
+        this.actionsToolbar.appendChild(toggleButton);
+        this.toolbarToggleButton = toggleButton;
+    }
+
+    private createToolbarRevealButton(): void {
+        if (this.toolbarRevealButton || !this.element) return;
+
+        const revealButton = document.createElement('button');
+        revealButton.type = 'button';
+        revealButton.className = 'btn btn-secondary btn-sm';
+        revealButton.setAttribute('aria-label', 'Show formatting toolbar');
+        revealButton.title = 'Show formatting toolbar';
+        revealButton.dataset.textEditorToolbarReveal = 'true';
+        revealButton.innerHTML = '<i class="fa-solid fa-ellipsis" aria-hidden="true"></i><span class="sr-only">Show formatting toolbar</span>';
+        revealButton.addEventListener('click', () => {
+            this.setToolbarHidden(false, true);
+        });
+
+        this.element.appendChild(revealButton);
+        this.toolbarRevealButton = revealButton;
+    }
+
+    private setToolbarHidden(hidden: boolean, persist: boolean): void {
+        this.toolbarHidden = hidden;
+        this.element.dataset.toolbarHidden = hidden ? 'true' : 'false';
+
+        if (this.actionsToolbar) {
+            this.actionsToolbar.dataset.toolbarHidden = hidden ? 'true' : 'false';
+        }
+
+        if (this.toolbarToggleButton) {
+            this.toolbarToggleButton.hidden = hidden;
+        }
+
+        if (this.toolbarRevealButton) {
+            this.toolbarRevealButton.hidden = !hidden;
+        }
+
+        if (!persist) return;
+
+        document.cookie = createToolbarVisibilityCookie(hidden);
+        window.dispatchEvent(new CustomEvent(TEXT_EDITOR_TOOLBAR_VISIBILITY_EVENT, {
+            detail: { hidden },
+        }));
     }
     
     public override onChange(): void {

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/text_editor/utils/toolbarVisibility.test.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/text_editor/utils/toolbarVisibility.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+    createToolbarVisibilityCookie,
+    isToolbarHiddenFromCookie,
+    TEXT_EDITOR_TOOLBAR_HIDDEN_COOKIE,
+} from './toolbarVisibility.ts';
+
+test('reads the hidden preference from a cookie string', () => {
+    assert.equal(isToolbarHiddenFromCookie('session=abc; bloomerp-text-editor-toolbar-hidden=true'), true);
+    assert.equal(isToolbarHiddenFromCookie('bloomerp-text-editor-toolbar-hidden=false'), false);
+    assert.equal(isToolbarHiddenFromCookie('session=abc'), false);
+});
+
+test('creates a persistent cookie for the shared toolbar preference', () => {
+    assert.equal(
+        createToolbarVisibilityCookie(true),
+        `${TEXT_EDITOR_TOOLBAR_HIDDEN_COOKIE}=true; path=/; max-age=31536000; SameSite=Lax`,
+    );
+});

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/text_editor/utils/toolbarVisibility.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/text_editor/utils/toolbarVisibility.ts
@@ -1,0 +1,23 @@
+export const TEXT_EDITOR_TOOLBAR_HIDDEN_COOKIE = "bloomerp-text-editor-toolbar-hidden";
+export const TEXT_EDITOR_TOOLBAR_VISIBILITY_EVENT = "bloomerp:text-editor-toolbar-visibility-change";
+
+const COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+export function isToolbarHiddenFromCookie(cookie: string): boolean {
+    return cookie.split(";").some((entry) => {
+        const separatorIndex = entry.indexOf("=");
+
+        if (separatorIndex === -1) {
+            return false;
+        }
+
+        const name = entry.slice(0, separatorIndex).trim();
+        const value = entry.slice(separatorIndex + 1).trim();
+
+        return name === TEXT_EDITOR_TOOLBAR_HIDDEN_COOKIE && value === "true";
+    });
+}
+
+export function createToolbarVisibilityCookie(hidden: boolean): string {
+    return `${TEXT_EDITOR_TOOLBAR_HIDDEN_COOKIE}=${hidden ? "true" : "false"}; path=/; max-age=${COOKIE_MAX_AGE_SECONDS}; SameSite=Lax`;
+}


### PR DESCRIPTION
## To-do

- ID: 577c149d-d1ea-44b5-a8e4-8bce67771e63
- Title: Add ability to globally hide toolbar for text editor

## Summary

- Add a persistent cookie-backed toolbar visibility preference shared by all text-editor instances.
- Broadcast visibility changes so current editors hide and reveal their toolbars together.
- Add a smooth collapse transition and a top-right restore control.
- Add focused tests for cookie parsing and serialization.

## Validation

- `node --experimental-strip-types --test ts/components/text_editor/utils/toolbarVisibility.test.ts` — 2 passed
- `npm run type-check` — passed
- `npm run build:js` — passed

The build emitted only existing bundler warnings about module directives, `eval`, and large chunks.