### PR TITLE
[BUG] Preserve cleared foreign-key relationships

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/ForeignFieldWidget.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/ForeignFieldWidget.ts
@@ -427,13 +427,33 @@ export default class ForeignFieldWidget extends BaseWidget {
         for (const inp of inputs) {
             if (inp.value === id) inp.remove();
         }
+        // Keep a named empty control so partial forms can distinguish a cleared
+        // relation from a field that was not included in the submission.
+        this.ensureEmptyValueInput();
+
         // if single select, clear visible input
-        if (!this.isM2M && this.input) this.input.value = '';
+        if (!this.isM2M) {
+            if (this.input) this.input.value = '';
+        }
         this.renderSelectedState();
 
         if (!this.valuesEqual(previousValue, this.getValue())) {
             this.onChange();
         }
+    }
+
+    private ensureEmptyValueInput(): void {
+        if (!this.fieldName) return;
+        if (this.element.querySelector(`input[type=hidden][name="${this.fieldName}"][data-empty-value="true"]`)) {
+            return;
+        }
+
+        const emptyValueInput = document.createElement('input');
+        emptyValueInput.type = 'hidden';
+        emptyValueInput.name = this.fieldName;
+        emptyValueInput.value = '';
+        emptyValueInput.dataset.emptyValue = 'true';
+        this.element.appendChild(emptyValueInput);
     }
 
     private getSelectionInputs(): HTMLInputElement[] {

--- a/bloomerp/django_bloomerp/bloomerp/tests/models/test_application_field.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/models/test_application_field.py
@@ -69,6 +69,22 @@ class TestApplicationField(BaseBloomerpModelTestCase):
             },
             use_bloomerp_base=True,
         )["CustomerLine"]
+        cls.CustomerRelationModel = create_test_models(
+            app_label="bloomerp",
+            model_defs={
+                "CustomerRelation": {
+                    "customer": models.ForeignKey(
+                        cls.CustomerModel,
+                        on_delete=models.SET_NULL,
+                        related_name="nullable_relations",
+                        blank=True,
+                        null=True,
+                    ),
+                    "__str__": lambda self: "Customer relation",
+                }
+            },
+            use_bloomerp_base=True,
+        )["CustomerRelation"]
         cls.PhoneRecordModel = create_test_models(
             app_label="bloomerp",
             model_defs={
@@ -982,6 +998,37 @@ class TestApplicationField(BaseBloomerpModelTestCase):
         self.assertEqual(prepared_data["first_name"], "Partial")
         self.assertEqual(prepared_data["last_name"], "Update")
         self.assertEqual(prepared_data["age"], "45")
+
+    def test_model_form_clears_foreign_key_when_partial_update_submits_empty_value(self):
+        """
+        Use case: A user removes a foreign-key relationship from an existing object.
+        Expected result: The partial model form saves the relation as null.
+        """
+
+        # 1. Create an object with an existing nullable foreign-key relation.
+        customer = self.create_customer("Related", "Customer", 44)
+        relation = self.CustomerRelationModel.objects.create(customer=customer)
+        form_class = bloomerp_modelform_factory(
+            self.CustomerRelationModel,
+            fields=["customer"],
+        )
+
+        # 2. Keep the empty foreign-key value explicitly in the submitted data.
+        prepared_data = form_class.prepare_bound_data(
+            QueryDict("customer=", mutable=True),
+            MultiValueDict(),
+            relation,
+            partial=True,
+        )
+
+        # 3. Validate and save the partial update.
+        form = form_class(data=prepared_data, instance=relation)
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+
+        # 4. Confirm the existing relationship was removed.
+        relation.refresh_from_db()
+        self.assertIsNone(relation.customer_id)
 
     def test_one_to_many_form_field_rejects_an_object_from_another_parent(self):
         customer = self.create_customer("First", "Parent", 40)

--- a/bloomerp/django_bloomerp/bloomerp/tests/test_foreign_field_widget.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/test_foreign_field_widget.py
@@ -33,6 +33,22 @@ class TestForeignFieldWidget(SimpleTestCase):
 
         self.assertEqual(value, "2")
 
+    def test_value_from_datadict_allows_an_explicit_empty_single_value(self):
+        """
+        Use case: A user clears a foreign-key selection before submitting an object.
+        Expected result: The empty hidden value is submitted instead of being treated as omitted.
+        """
+
+        # 1. Build the same two-value submission produced when a selected relation is cleared.
+        widget = ForeignFieldWidget()
+        data = QueryDict("label=1&label=", mutable=True)
+
+        # 2. Read the submitted values from the custom widget.
+        value = widget.value_from_datadict(data, {}, "label")
+
+        # 3. Preserve the explicit empty value so partial updates can clear the relation.
+        self.assertEqual(value, "")
+
     def test_get_context_includes_selected_urls_json(self):
         class DummyObject:
             pk = 7


### PR DESCRIPTION
Todo: [BUG] Removing a foreign key relationship via the foreign-key field from an object does not work anymore.
Todo ID: The configured backend Todo collection did not return a matching record; requested branch suffix: ba0f.

Summary:
- Preserve a named empty hidden value when a relation is removed from ForeignFieldWidget.
- Keep partial model-form updates able to distinguish an explicit clear from an omitted field.
- Add widget and model-form regression coverage.

Verification:
- npm run type-check — passed.
- UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.test_foreign_field_widget — passed, 5 tests.
- UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python -m py_compile bloomerp/forms/model_form.py bloomerp/widgets/foreign_field_widget.py bloomerp/tests/test_foreign_field_widget.py bloomerp/tests/models/test_application_field.py — passed.
- PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py check — passed with existing third-party model warnings.
- The broader test selection was blocked by a pre-existing ImportError: save_submitted_one_to_many_fields is missing from bloomerp.services.one_to_many_field_services.