### PR TITLE
Fix boolean fields in one-to-many widgets

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/OneToManyFieldWidget.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/OneToManyFieldWidget.ts
@@ -710,7 +710,11 @@ export default class OneToManyFieldWidget extends BaseWidget {
     }
 
     private getColumnValue(row: HTMLElement, fieldName: string): string {
-        return this.getColumnControl(row, fieldName)?.value ?? "";
+        const control = this.getColumnControl(row, fieldName);
+        if (control instanceof HTMLInputElement && control.type === "checkbox") {
+            return control.checked ? "true" : "false";
+        }
+        return control?.value ?? "";
     }
 
     private getColumnKind(fieldName: string): string {
@@ -721,7 +725,15 @@ export default class OneToManyFieldWidget extends BaseWidget {
 
     private setColumnValue(row: HTMLElement, fieldName: string, value: string): void {
         const control = this.getColumnControl(row, fieldName);
-        if (control) control.value = value;
+        if (!control) return;
+        if (control instanceof HTMLInputElement && control.type === "checkbox") {
+            control.checked = value === "true"
+                || value === "1"
+                || value === "on"
+                || value === "yes";
+            return;
+        }
+        control.value = value;
     }
 
     private toNumber(value: string): number {

--- a/bloomerp/django_bloomerp/bloomerp/tests/widgets/test_one_to_many_field_widget.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/widgets/test_one_to_many_field_widget.py
@@ -1,6 +1,7 @@
 from bs4 import BeautifulSoup
 from django.http import QueryDict
 
+from bloomerp.models.workspaces.sidebar_item import SidebarItem
 from bloomerp.tests.base import BaseBloomerpModelTestCase
 from bloomerp.widgets.one_to_many_field_widget import OneToManyFieldWidget
 
@@ -126,6 +127,44 @@ class TestCreateView(BaseBloomerpModelTestCase):
         self.assertIsNotNone(editor)
         self.assertIn("min-h-36", editor.get("class", []))
         self.assertNotIn("min-h-72", editor.get("class", []))
+
+    def test_widget_renders_boolean_inline_fields(self):
+        """
+        Use case: Render a boolean field as an inline one-to-many column.
+        Expected result: The boolean input is present and reflects each row value.
+        """
+        # 1. Render child rows containing both checked and unchecked values.
+        widget = OneToManyFieldWidget(
+            attrs={
+                "related_model": SidebarItem,
+                "parent_model": SidebarItem,
+                "layout_config": {"inline_fields": ["name", "is_folder"]},
+            }
+        )
+        soup = BeautifulSoup(
+            widget.render(
+                name="children",
+                value=[
+                    {"name": "Folder", "is_folder": True},
+                    {"name": "Item", "is_folder": False},
+                ],
+                attrs={},
+            ),
+            "html.parser",
+        )
+
+        # 2. Verify each row includes a checkbox with the submitted state.
+        boolean_inputs = soup.select(
+            '[data-one-to-many-body] > tr[data-one-to-many-row] '
+            '[data-one-to-many-cell="is_folder"] input[type="checkbox"]'
+        )
+        self.assertEqual(len(boolean_inputs), 2)
+        self.assertIn("checked", boolean_inputs[0].attrs)
+        self.assertNotIn("checked", boolean_inputs[1].attrs)
+        self.assertEqual(
+            soup.select_one('[data-one-to-many-column="is_folder"]')["data-column-kind"],
+            "boolean",
+        )
 
     def test_widget_collects_nested_rows_for_form_cleaning(self):
         widget = OneToManyFieldWidget()

--- a/bloomerp/django_bloomerp/bloomerp/widgets/one_to_many_field_widget.py
+++ b/bloomerp/django_bloomerp/bloomerp/widgets/one_to_many_field_widget.py
@@ -176,6 +176,8 @@ class OneToManyFieldWidget(widgets.Widget):
         except Exception:
             return "text"
 
+        if isinstance(model_field, models.BooleanField):
+            return "boolean"
         if isinstance(model_field, models.DateField):
             return "date"
         if isinstance(

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.12.0beta28"
+version = "1.12.0beta29"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## To-do

- **ID:** 9950b2e0-f8ce-4d61-a366-97dd19178fe8
- **Title:** [BUG] boolean field not rendering in o2m field

## Summary

- Classify boolean inline columns explicitly in the O2M widget metadata.
- Preserve checked/unchecked semantics when reading and copying checkbox controls.
- Add a regression test covering checked and unchecked boolean child rows.

## Validation

- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache UV_CACHE_DIR=/tmp/bloomerp-uv-cache uv run python manage.py test bloomerp.tests.widgets.test_one_to_many_field_widget --verbosity 1` — passed (7 tests).
- `npm run type-check` — passed.
- `git diff --check` — passed.
- The adjacent `bloomerp.tests.models.test_application_field` module was not runnable because the base branch has a pre-existing import mismatch for `save_submitted_one_to_many_fields`.
