### PR TITLE
Preserve created_by on object updates

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/services/activity_log_services.py
+++ b/bloomerp/django_bloomerp/bloomerp/services/activity_log_services.py
@@ -72,10 +72,10 @@ class ActivityLogManager:
         if user is None:
             return
 
-        if hasattr(self.instance, "created_by") and not (user.is_anonymous):
+        if self.is_create and hasattr(self.instance, "created_by") and not user.is_anonymous:
             setattr(self.instance, "created_by", user)
             
-        if hasattr(self.instance, "updated_by") and not (user.is_anonymous):
+        if hasattr(self.instance, "updated_by") and not user.is_anonymous:
             setattr(self.instance, "updated_by", user)
         
     def set_delete(self) -> None:

--- a/bloomerp/django_bloomerp/bloomerp/tests/services/test_activity_log_services.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/services/test_activity_log_services.py
@@ -1,4 +1,5 @@
 import uuid
+from types import SimpleNamespace
 
 from bloomerp.models.activity_log import ActivityLog, ActivityLogAction
 from bloomerp.models.definition import BloomerpModelConfig
@@ -71,6 +72,26 @@ class ActivityLogManagerTestCase(BaseBloomerpModelTestCase):
 
         self.assertIsNone(activity_log)
         self.assertEqual(ActivityLog.objects.count(), 0)
+
+    def test_set_changes_preserves_created_by_when_updating(self):
+        """
+        Use case: A different authenticated user updates an existing object.
+        Expected result: The creator is preserved and only updated_by changes.
+        """
+        # 1. Save the original creator on an existing object.
+        self.customer.created_by = self.admin_user
+        self.customer.updated_by = self.admin_user
+        self.customer.save()
+
+        # 2. Prepare an update as another authenticated user.
+        self.customer.first_name = "Grace"
+        request = SimpleNamespace(user=self.normal_user)
+        manager = ActivityLogManager(self.customer, request)
+        manager.set_changes()
+
+        # 3. Confirm the immutable creator remains intact while the updater changes.
+        self.assertEqual(self.customer.created_by, self.admin_user)
+        self.assertEqual(self.customer.updated_by, self.normal_user)
 
     def test_serializer_lookup_registers_missing_serializer_lazily(self):
         _model_serializers.pop(self.CustomerModel, None)

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.12.0beta29"
+version = "1.12.0beta30"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## To-do

- ID: `3e139b96-b548-4fa1-a0cb-4b08fb6996f1`
- Title: `[BUG] Created by field get's overwritten on update`

## What changed

- Stamp `created_by` only when the model instance is being created.
- Continue stamping `updated_by` for authenticated updates.
- Add a regression test proving that a second user can update an object without replacing its original creator.

## Root cause and impact

`ActivityLogManager.set_changes()` assigned the current request user to both audit fields on every save. Updating an existing record therefore replaced its historical creator. The creator is now preserved while the latest updater is still recorded.

## Validation

Passed:

- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.services.test_activity_log_services.ActivityLogManagerTestCase.test_set_changes_preserves_created_by_when_updating`
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py check`
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache python -m py_compile bloomerp/django_bloomerp/bloomerp/services/activity_log_services.py bloomerp/django_bloomerp/bloomerp/tests/services/test_activity_log_services.py`
- `git diff --check`

Broader service test result:

- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.services.test_activity_log_services` — 9 passed, 1 pre-existing unrelated error. `test_persist_accepts_uuid_values_in_payload` expects `ActivityLogManager.persist()` to return the created log, but the current method returns `None`. This PR does not alter that unrelated behavior.
