### PR TITLE
Fix one-to-many editor focus and checkbox contrast

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/layouts/BaseSectionedLayoutContainer.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/layouts/BaseSectionedLayoutContainer.ts
@@ -1316,7 +1316,7 @@ export default abstract class BaseSectionedLayoutContainer<TItem extends BaseSec
     protected isInteractiveTarget(target: HTMLElement): boolean {
         return Boolean(
             target.closest(
-                "input, textarea, select, option, button, a, [contenteditable=\"true\"], [data-row-controls], [data-layout-item-controls], [data-layout-sidebar-item]",
+                "input, textarea, select, option, button, a, [contenteditable=\"true\"], [bloomerp-component=\"bloomerp-text-editor\"], [data-row-controls], [data-layout-item-controls], [data-layout-sidebar-item]",
             ),
         );
     }

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/text_editor/BloomerpTextEditor.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/text_editor/BloomerpTextEditor.ts
@@ -68,6 +68,7 @@ export class BloomerpTextEditor extends BaseWidget {
     private editorId:string;
     private includeToolbar:boolean = true;
     private editorRootSelector:string = '';
+    private hostClickHandler: ((event: MouseEvent) => void) | null = null;
 
     // Extra commands
     public slashExtraActions:string[] = []
@@ -151,6 +152,11 @@ export class BloomerpTextEditor extends BaseWidget {
         window.addEventListener(TEXT_EDITOR_TOOLBAR_VISIBILITY_EVENT, this.toolbarVisibilityHandler);
 
         this.editor.setRootElement(editorRef);
+        this.hostClickHandler = (event: MouseEvent) => {
+            if (event.target !== this.element) return;
+            this.editor?.focus();
+        };
+        this.element.addEventListener('click', this.hostClickHandler);
         this.isInitializing = true;
         this.setValue(this.hiddenInput?.value ?? '', false);
 
@@ -188,6 +194,11 @@ export class BloomerpTextEditor extends BaseWidget {
     }
 
     public destroy(): void {
+        if (this.hostClickHandler) {
+            this.element?.removeEventListener('click', this.hostClickHandler);
+            this.hostClickHandler = null;
+        }
+
         if (this.toolbarVisibilityHandler) {
             window.removeEventListener(
                 TEXT_EDITOR_TOOLBAR_VISIBILITY_EVENT,

--- a/bloomerp/django_bloomerp/bloomerp/tests/e2e/widgets/test_one_to_many_widget_e2e.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/e2e/widgets/test_one_to_many_widget_e2e.py
@@ -187,14 +187,18 @@ class TestOneToManyWidgetE2E(TestCrudE2EMixin, BaseE2ETestCase):
 
     def test_text_editors_update_their_own_one_to_many_rows(self):
         """
-        Use case: Edit text-editor fields in two newly added one-to-many rows.
+        Use case: Edit text-editor fields in two server-rendered one-to-many rows.
         Expected result: Each editor updates only the hidden input in its own row.
         """
-        # 1. Open an empty country form and add two customer rows.
-        self.goto(self.get_base_url())
-        add_row_button = self.get_widget().get_by_role("button", name="Add row")
-        add_row_button.click()
-        add_row_button.click()
+        # 1. Open a country form with two text-editor rows already rendered.
+        self.goto(
+            self.get_url_with_rows(
+                [
+                    {"description": "First customer description"},
+                    {"description": "Second customer description"},
+                ]
+            )
+        )
         expect(self.get_rows()).to_have_count(2)
 
         # 2. Enter different content in each row's text editor.
@@ -204,8 +208,17 @@ class TestOneToManyWidgetE2E(TestCrudE2EMixin, BaseE2ETestCase):
         second_editor = self.get_rows().nth(1).locator(
             '[data-one-to-many-cell="description"] .bloomerp-text-editor'
         )
-        first_editor.fill("First customer description")
-        second_editor.fill("Second customer description")
+        first_editor.focus()
+        expect(first_editor).to_be_focused()
+        second_editor_wrapper = self.get_rows().nth(1).locator(
+            '[data-one-to-many-cell="description"] '
+            '[bloomerp-component="bloomerp-text-editor"]'
+        )
+        second_editor_wrapper.dispatch_event("click")
+        expect(second_editor).to_be_focused()
+        expect(first_editor).not_to_be_focused()
+        first_editor.fill("Updated first customer description")
+        second_editor.fill("Updated second customer description")
 
         # 3. Verify each editor synchronized its own row's form input.
         first_value = self.get_rows().nth(0).locator(
@@ -214,10 +227,10 @@ class TestOneToManyWidgetE2E(TestCrudE2EMixin, BaseE2ETestCase):
         second_value = self.get_rows().nth(1).locator(
             '[data-one-to-many-cell="description"] [data-text-editor-input="true"]'
         ).input_value()
-        self.assertIn("First customer description", first_value)
-        self.assertNotIn("Second customer description", first_value)
-        self.assertIn("Second customer description", second_value)
-        self.assertNotIn("First customer description", second_value)
+        self.assertIn("Updated first customer description", first_value)
+        self.assertNotIn("Updated second customer description", first_value)
+        self.assertIn("Updated second customer description", second_value)
+        self.assertNotIn("Updated first customer description", second_value)
 
     def test_preview_icon_previews_and_opens_persisted_row(self):
         """

--- a/bloomerp/django_bloomerp/bloomerp/tests/widgets/test_one_to_many_field_widget.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/widgets/test_one_to_many_field_widget.py
@@ -161,6 +161,8 @@ class TestCreateView(BaseBloomerpModelTestCase):
         self.assertEqual(len(boolean_inputs), 2)
         self.assertIn("checked", boolean_inputs[0].attrs)
         self.assertNotIn("checked", boolean_inputs[1].attrs)
+        self.assertIn("text-primary", boolean_inputs[0].get("class", []))
+        self.assertNotIn("bg-transparent", boolean_inputs[0].get("class", []))
         self.assertEqual(
             soup.select_one('[data-one-to-many-column="is_folder"]')["data-column-kind"],
             "boolean",

--- a/bloomerp/django_bloomerp/bloomerp/widgets/one_to_many_field_widget.py
+++ b/bloomerp/django_bloomerp/bloomerp/widgets/one_to_many_field_widget.py
@@ -123,9 +123,18 @@ class OneToManyFieldWidget(widgets.Widget):
         row_index,
         default_values=None,
     ):
-        cell_attrs = {
-            "class": "one-to-many-field-widget__input input input-sm w-full border-0 bg-transparent px-2 py-1 shadow-none focus:bg-white",
-        }
+        widget = application_field.get_widget()
+        if isinstance(widget, widgets.CheckboxInput):
+            input_classes = (
+                "one-to-many-field-widget__input h-5 w-5 cursor-pointer rounded "
+                "border-gray-400 text-primary focus:ring-primary"
+            )
+        else:
+            input_classes = (
+                "one-to-many-field-widget__input input input-sm w-full border-0 "
+                "bg-transparent px-2 py-1 shadow-none focus:bg-white"
+            )
+        cell_attrs = {"class": input_classes}
         if attrs and attrs.get("disabled"):
             cell_attrs["disabled"] = "disabled"
         if attrs and attrs.get("readonly"):
@@ -136,7 +145,6 @@ class OneToManyFieldWidget(widgets.Widget):
             application_field=application_field,
             default_values=default_values,
         )
-        widget = application_field.get_widget()
         return widget.render(
             name=f"{name}__{row_index}__{application_field.field}",
             value=value,


### PR DESCRIPTION
Follow-up acceptance fixes for:

- 8ee5 — Bug: text editor when shown in one-to-many only allows updating the first occurrence
- 8fe8 — Bug: boolean field not rendering in O2M field

Implementation summary:
- Give inline BooleanField widgets checkbox-specific sizing and primary-color styling instead of the shared transparent input background, restoring a visible checked state.
- Treat text-editor wrappers as interactive layout targets and focus the editor belonging to the clicked wrapper, preventing blank-area clicks in later O2M rows from redirecting focus to the first editor.
- Strengthen the server-rendered multi-row browser regression and checkbox rendering assertions.

Verification:
- .venv/bin/pytest bloomerp/tests/widgets/test_one_to_many_field_widget.py -q — 7 passed
- .venv/bin/pytest bloomerp/tests/e2e/widgets/test_one_to_many_widget_e2e.py::TestOneToManyWidgetE2E::test_text_editors_update_their_own_one_to_many_rows -q — 1 passed
- npm run build — passed (TypeScript, Tailwind, and Vite production build)
- .venv/bin/python manage.py check — passed with existing model-configuration warnings; 0 issues

No new backend Todo record was supplied for this acceptance follow-up, so no Todo assignment/status update was performed.