### PR TITLE
Fix inactive workflow runtime checks

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/celery/tasks/workflow_task.py
+++ b/bloomerp/django_bloomerp/bloomerp/celery/tasks/workflow_task.py
@@ -26,7 +26,10 @@ def run_workflow_async(workflow_id, trigger_data, start_node_id=None):
         serialize_workflow_run_result,
     )
 
-    workflow = Workflow.objects.get(id=workflow_id)
+    workflow = Workflow.objects.filter(id=workflow_id, active=True).first()
+    if workflow is None:
+        return None
+
     deserialized_trigger_data = _deserialize_trigger_data(trigger_data)
     start_node = (
         workflow.nodes.get(id=start_node_id)

--- a/bloomerp/django_bloomerp/bloomerp/models/automation/workflow_node.py
+++ b/bloomerp/django_bloomerp/bloomerp/models/automation/workflow_node.py
@@ -160,13 +160,9 @@ class WorkflowNode(
         Returns:
             QuerySet["WorkflowNode"]: QuerySet of WorkflowNode objects matching the trigger subtype.
         """
-        return WorkflowNode.objects.filter(
-            config__sub_type=trigger_subtype,
-            workflow__active=True,
-        )
+        return WorkflowNode.objects.filter(config__sub_type=trigger_subtype)
 
     
     
-
 
 

--- a/bloomerp/django_bloomerp/bloomerp/services/workflow_services.py
+++ b/bloomerp/django_bloomerp/bloomerp/services/workflow_services.py
@@ -272,6 +272,12 @@ def serialize_workflow_run_result(workflow_run: WorkflowRun | None) -> dict | No
         "workflow_run_id": str(workflow_run.id),
     }
 
+
+def _get_active_workflow(workflow: Workflow) -> Workflow | None:
+    """Return the current database state only when the workflow is active."""
+    return Workflow.objects.filter(pk=workflow.pk, active=True).first()
+
+
 def run_workflow(
     workflow: Workflow,
     trigger_data: dict,
@@ -286,6 +292,10 @@ def run_workflow(
     """
     if start_node is not None and start_node.workflow_id != workflow.id:
         raise ValueError("Start node does not belong to the workflow.")
+
+    workflow = _get_active_workflow(workflow)
+    if workflow is None:
+        return None
 
     if workflow.run_asynchronously:
         serialized_trigger_data = _serialize_trigger_data(trigger_data)
@@ -615,9 +625,13 @@ def run_workflow_sync(
     workflow: Workflow,
     trigger_data: dict,
     start_node: WorkflowNode | None = None,
-) -> WorkflowRun:
+) -> WorkflowRun | None:
     if start_node is not None and start_node.workflow_id != workflow.id:
         raise ValueError("Start node does not belong to the workflow.")
+
+    workflow = _get_active_workflow(workflow)
+    if workflow is None:
+        return None
 
     workflow_run = WorkflowRun.objects.create(workflow=workflow)
     state = WorkflowRunState(

--- a/bloomerp/django_bloomerp/bloomerp/tests/automation/test_automation.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/automation/test_automation.py
@@ -24,6 +24,7 @@ from bloomerp.services.workflow_services import (
     format_execution_trace,
     resume_workflow,
     run_workflow,
+    run_workflow_sync,
 )
 from bloomerp.signals.automation_signals import setup_automation_signals
 from bloomerp.tests.utils.dynamic_models import create_test_models, ensure_content_types_for_models
@@ -380,6 +381,37 @@ class TestAutomation(TransactionTestCase):
             self.end_node.id,
         )
 
+    def test_run_workflow_skips_a_workflow_deactivated_in_the_database(self):
+        """
+        Use case: A caller holds an active workflow instance after it is deactivated elsewhere.
+        Expected result: The workflow is not queued or executed from stale in-memory state.
+        """
+        # 1. Configure asynchronous execution and retain the active model instance.
+        self.workflow.run_asynchronously = True
+        self.workflow.save(update_fields=["run_asynchronously"])
+        Workflow.objects.filter(pk=self.workflow.pk).update(active=False)
+
+        # 2. Attempt dispatch with the stale instance and verify nothing is queued.
+        with patch("bloomerp.services.workflow_services.run_workflow_async.delay") as delay_mock:
+            result = run_workflow(self.workflow, {"first_name": "John"})
+
+        self.assertIsNone(result)
+        delay_mock.assert_not_called()
+
+    def test_run_workflow_sync_skips_a_workflow_deactivated_in_the_database(self):
+        """
+        Use case: A direct synchronous caller holds stale active workflow state.
+        Expected result: No workflow run is created after database deactivation.
+        """
+        # 1. Deactivate the workflow without updating the in-memory instance.
+        Workflow.objects.filter(pk=self.workflow.pk).update(active=False)
+
+        # 2. Attempt synchronous execution and verify no run is persisted.
+        result = run_workflow_sync(self.workflow, {"first_name": "John"})
+
+        self.assertIsNone(result)
+        self.assertFalse(WorkflowRun.objects.filter(workflow=self.workflow).exists())
+
     def test_run_workflow_async_hydrates_model_instances_before_running_sync(self):
         workflow = Workflow.objects.create(
             name="Async employee workflow",
@@ -435,6 +467,23 @@ class TestAutomation(TransactionTestCase):
             result = run_workflow_async(self.workflow.id, {"first_name": "John"})
 
         self.assertEqual(result, {"workflow_run_id": "123"})
+
+    def test_run_workflow_async_skips_a_workflow_deactivated_after_queueing(self):
+        """
+        Use case: An asynchronous workflow is deactivated after its task is queued.
+        Expected result: The worker drops the task before synchronous execution.
+        """
+        # 1. Simulate deactivation after a task has already captured the workflow id.
+        workflow_id = self.workflow.id
+        self.workflow.active = False
+        self.workflow.save(update_fields=["active"])
+
+        # 2. Run the queued task and verify it does not enter the workflow engine.
+        with patch("bloomerp.services.workflow_services.run_workflow_sync") as run_workflow_sync_mock:
+            result = run_workflow_async(workflow_id, {"first_name": "John"})
+
+        self.assertIsNone(result)
+        run_workflow_sync_mock.assert_not_called()
 
     # ----------------------------------------
     # Trigger: SCHEDULE
@@ -648,15 +697,133 @@ class TestAutomation(TransactionTestCase):
             run_workflow_mock.assert_called_once()
             self.assertEqual(run_workflow_mock.call_args.args[1]["event"], "update")
 
-    def test_inactive_workflow_does_not_run_after_create(self):
+    def test_deactivated_workflow_does_not_run_after_create(self):
         """
-        Use case: An inactive workflow has an object-create trigger.
-        Expected result: Creating the matching object does not run the workflow.
+        Use case: An active object-create workflow is deactivated after signal registration.
+        Expected result: Creating the matching object does not run the deactivated workflow.
         """
-        # 1. Create an inactive workflow with a matching object-create trigger.
+        # 1. Register an active workflow with a matching object-create trigger.
         content_type = ContentType.objects.get_for_model(self.CustomerModel)
         workflow = Workflow.objects.create(
-            name="Inactive Create Trigger Workflow",
+            name="Deactivated Create Trigger Workflow",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        WorkflowNode.objects.create(
+            workflow=workflow,
+            config={
+                "sub_type": "ON_OBJECT_CREATE",
+                "parameters": {"content_type_id": content_type.id},
+            },
+            type=WorkflowNodeType.TRIGGER.value.id,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        setup_automation_signals(refresh=True)
+        workflow.active = False
+        workflow.save(update_fields=["active"])
+
+        # 2. Create the matching object and verify execution is skipped at runtime.
+        with patch("bloomerp.services.workflow_services.run_workflow_sync") as run_workflow_sync_mock:
+            self.CustomerModel.objects.create(
+                first_name="Deactivated",
+                last_name="Create",
+                age=30,
+                created_by=self.user,
+                updated_by=self.user,
+            )
+
+        run_workflow_sync_mock.assert_not_called()
+
+    def test_deactivated_workflow_does_not_run_after_update(self):
+        """
+        Use case: An active object-update workflow is deactivated after signal registration.
+        Expected result: Updating the matching object does not run the deactivated workflow.
+        """
+        # 1. Register an active workflow with a matching object-update trigger.
+        content_type = ContentType.objects.get_for_model(self.CustomerModel)
+        workflow = Workflow.objects.create(
+            name="Deactivated Update Trigger Workflow",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        WorkflowNode.objects.create(
+            workflow=workflow,
+            config={
+                "sub_type": "ON_OBJECT_UPDATE",
+                "parameters": {"content_type_id": content_type.id},
+            },
+            type=WorkflowNodeType.TRIGGER.value.id,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        setup_automation_signals(refresh=True)
+        instance = self.CustomerModel.objects.create(
+            first_name="Deactivated",
+            last_name="Update",
+            age=30,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        workflow.active = False
+        workflow.save(update_fields=["active"])
+
+        # 2. Update the matching object and verify execution is skipped at runtime.
+        with patch("bloomerp.services.workflow_services.run_workflow_sync") as run_workflow_sync_mock:
+            instance.age = 31
+            instance.updated_by = self.user
+            instance.save()
+
+        run_workflow_sync_mock.assert_not_called()
+
+    def test_deactivated_workflow_does_not_run_after_delete(self):
+        """
+        Use case: An active object-delete workflow is deactivated after signal registration.
+        Expected result: Deleting the matching object does not run the deactivated workflow.
+        """
+        # 1. Register an active workflow with a matching object-delete trigger.
+        content_type = ContentType.objects.get_for_model(self.CustomerModel)
+        workflow = Workflow.objects.create(
+            name="Deactivated Delete Trigger Workflow",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        WorkflowNode.objects.create(
+            workflow=workflow,
+            config={
+                "sub_type": "ON_OBJECT_DELETE",
+                "parameters": {"content_type_id": content_type.id},
+            },
+            type=WorkflowNodeType.TRIGGER.value.id,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        setup_automation_signals(refresh=True)
+        instance = self.CustomerModel.objects.create(
+            first_name="Deactivated",
+            last_name="Delete",
+            age=30,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        workflow.active = False
+        workflow.save(update_fields=["active"])
+
+        # 2. Delete the matching object and verify execution is skipped at runtime.
+        with patch("bloomerp.services.workflow_services.run_workflow_sync") as run_workflow_sync_mock:
+            instance.delete()
+
+        run_workflow_sync_mock.assert_not_called()
+
+    def test_reactivated_workflow_runs_without_signal_refresh(self):
+        """
+        Use case: An inactive object-create workflow is registered and later activated.
+        Expected result: It starts running without rebuilding process-local signal handlers.
+        """
+        # 1. Register an inactive workflow with a matching object-create trigger.
+        content_type = ContentType.objects.get_for_model(self.CustomerModel)
+        workflow = Workflow.objects.create(
+            name="Reactivated Create Trigger Workflow",
             active=False,
             created_by=self.user,
             updated_by=self.user,
@@ -673,95 +840,28 @@ class TestAutomation(TransactionTestCase):
         )
         setup_automation_signals(refresh=True)
 
-        # 2. Create the matching object and verify no workflow run is started.
-        with patch("bloomerp.signals.automation_signals.run_workflow") as run_workflow_mock:
+        # 2. Verify it is skipped while inactive, then activate it without refreshing signals.
+        with patch("bloomerp.services.workflow_services.run_workflow_sync") as run_workflow_sync_mock:
             self.CustomerModel.objects.create(
-                first_name="Inactive",
-                last_name="Create",
+                first_name="Before",
+                last_name="Activation",
                 age=30,
                 created_by=self.user,
                 updated_by=self.user,
             )
+            run_workflow_sync_mock.assert_not_called()
 
-        run_workflow_mock.assert_not_called()
+            workflow.active = True
+            workflow.save(update_fields=["active"])
+            self.CustomerModel.objects.create(
+                first_name="After",
+                last_name="Activation",
+                age=31,
+                created_by=self.user,
+                updated_by=self.user,
+            )
 
-    def test_inactive_workflow_does_not_run_after_update(self):
-        """
-        Use case: An inactive workflow has an object-update trigger.
-        Expected result: Updating the matching object does not run the workflow.
-        """
-        # 1. Create an inactive workflow with a matching object-update trigger.
-        content_type = ContentType.objects.get_for_model(self.CustomerModel)
-        workflow = Workflow.objects.create(
-            name="Inactive Update Trigger Workflow",
-            active=False,
-            created_by=self.user,
-            updated_by=self.user,
-        )
-        WorkflowNode.objects.create(
-            workflow=workflow,
-            config={
-                "sub_type": "ON_OBJECT_UPDATE",
-                "parameters": {"content_type_id": content_type.id},
-            },
-            type=WorkflowNodeType.TRIGGER.value.id,
-            created_by=self.user,
-            updated_by=self.user,
-        )
-        setup_automation_signals(refresh=True)
-        instance = self.CustomerModel.objects.create(
-            first_name="Inactive",
-            last_name="Update",
-            age=30,
-            created_by=self.user,
-            updated_by=self.user,
-        )
-
-        # 2. Update the matching object and verify no workflow run is started.
-        with patch("bloomerp.signals.automation_signals.run_workflow") as run_workflow_mock:
-            instance.age = 31
-            instance.updated_by = self.user
-            instance.save()
-
-        run_workflow_mock.assert_not_called()
-
-    def test_inactive_workflow_does_not_run_after_delete(self):
-        """
-        Use case: An inactive workflow has an object-delete trigger.
-        Expected result: Deleting the matching object does not run the workflow.
-        """
-        # 1. Create an inactive workflow with a matching object-delete trigger.
-        content_type = ContentType.objects.get_for_model(self.CustomerModel)
-        workflow = Workflow.objects.create(
-            name="Inactive Delete Trigger Workflow",
-            active=False,
-            created_by=self.user,
-            updated_by=self.user,
-        )
-        WorkflowNode.objects.create(
-            workflow=workflow,
-            config={
-                "sub_type": "ON_OBJECT_DELETE",
-                "parameters": {"content_type_id": content_type.id},
-            },
-            type=WorkflowNodeType.TRIGGER.value.id,
-            created_by=self.user,
-            updated_by=self.user,
-        )
-        setup_automation_signals(refresh=True)
-        instance = self.CustomerModel.objects.create(
-            first_name="Inactive",
-            last_name="Delete",
-            age=30,
-            created_by=self.user,
-            updated_by=self.user,
-        )
-
-        # 2. Delete the matching object and verify no workflow run is started.
-        with patch("bloomerp.signals.automation_signals.run_workflow") as run_workflow_mock:
-            instance.delete()
-
-        run_workflow_mock.assert_not_called()
+        run_workflow_sync_mock.assert_called_once()
     
     def test_exeucte_node(self):
         """Tests the execution of a basic node"""


### PR DESCRIPTION
## Follow-up

Fixes the production acceptance failure from #104 for Todo `672e51ec-c972-404e-af3c-67b747e10805` — `[BUG] Workflow runs ON_CREATE / ON_UPDATE / ON_DELETE even if deactivated`.

## Root cause

PR #104 filtered inactive workflows only while process-local Django signal handlers were registered. Deactivating an already-registered workflow left a closure holding its trigger, so production object events continued to dispatch it until handlers were refreshed or the process restarted.

## What changed

- Register object workflow triggers regardless of their current active state.
- Reload and require current active database state before synchronous execution or asynchronous dispatch.
- Recheck active state inside the Celery worker so workflows deactivated after queueing are dropped.
- Replace registration-only regression coverage with active-to-inactive lifecycle tests for create, update, and delete.
- Add coverage for stale model instances, direct synchronous calls, queued tasks, and reactivation without signal refresh.

## Impact

Deactivation now takes effect without restarting application workers or editing workflow nodes. Inactive workflows do not create runs or enqueue tasks, and reactivated object workflows begin working without rebuilding process-local signal handlers.

## Validation

- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run pytest bloomerp/tests/automation/test_automation.py -k 'run_workflow_called_after or deactivated_workflow or reactivated_workflow or run_workflow_skips_a_workflow or run_workflow_sync_skips_a_workflow or run_workflow_async_skips_a_workflow or run_workflow_async_returns_json_safe_result or run_workflow_queues_celery_task'` — 13 passed.
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py check` — passed; existing third-party `django_celery_beat` model warnings only.
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python -m py_compile bloomerp/models/automation/workflow_node.py bloomerp/services/workflow_services.py bloomerp/celery/tasks/workflow_task.py bloomerp/tests/automation/test_automation.py` — passed.
- Full automation module: 49 passed, 14 pre-existing failures in action/condition/branch/human-trigger coverage. PR #104 likewise documented the existing broader module failures; none intersect the focused runtime lifecycle coverage above.

## Scope

The unrelated local `bloomerp/django_bloomerp/uv.lock` version change was intentionally excluded.