### PR TITLE
Fix create user view rendering

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/templates/views/users/create.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/views/users/create.html
@@ -1,0 +1,25 @@
+{% load crispy_forms_tags %}
+
+<c-ui.container class="mt-16 max-w-3xl">
+    <form
+        method="post"
+        action="{{ request.path }}"
+        hx-post="{{ request.path }}"
+        hx-target="#main-content"
+        hx-swap="innerHTML"
+        class="space-y-4"
+    >
+        {% csrf_token %}
+        <c-ui.text.title>
+            <c-i18n.blocktrans>Create user</c-i18n.blocktrans>
+        </c-ui.text.title>
+
+        <div>
+            {{ form|crispy }}
+        </div>
+
+        <button class="btn btn-primary" type="submit">
+            <c-i18n.blocktrans>Create user</c-i18n.blocktrans>
+        </button>
+    </form>
+</c-ui.container>

--- a/bloomerp/django_bloomerp/bloomerp/templates/views/users/create.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/views/users/create.html
@@ -4,9 +4,12 @@
     <form
         method="post"
         action="{{ request.path }}"
+        enctype="multipart/form-data"
         hx-post="{{ request.path }}"
+        hx-encoding="multipart/form-data"
         hx-target="#main-content"
         hx-swap="innerHTML"
+        hx-push-url="true"
         class="space-y-4"
     >
         {% csrf_token %}

--- a/bloomerp/django_bloomerp/bloomerp/tests/views/create_user.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/views/create_user.py
@@ -81,6 +81,22 @@ class TestCreateUserView(BaseBloomerpModelTestCase):
         )
         self.assertEqual(authenticated_user, created_user)
 
+    def test_create_user_form_renders(self):
+        """
+        Use case: An administrator opens the create-user view.
+        Expected result: The password-aware user creation form is rendered.
+        """
+        # 1. Log in as the administrator and open the create-user view.
+        self.client.force_login(self.admin_user)
+        response = self.client.get(self.get_url())
+
+        # 2. Confirm the view renders the fields needed to create a user.
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "views/users/create.html")
+        self.assertContains(response, 'name="username"')
+        self.assertContains(response, 'name="password1"')
+        self.assertContains(response, 'name="password2"')
+
     def test_create_route_is_bound_to_the_active_user_model(self):
         match = resolve(self.get_url())
 

--- a/bloomerp/django_bloomerp/bloomerp/tests/views/create_user.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/views/create_user.py
@@ -96,6 +96,9 @@ class TestCreateUserView(BaseBloomerpModelTestCase):
         self.assertContains(response, 'name="username"')
         self.assertContains(response, 'name="password1"')
         self.assertContains(response, 'name="password2"')
+        self.assertContains(response, 'enctype="multipart/form-data"')
+        self.assertContains(response, 'hx-encoding="multipart/form-data"')
+        self.assertContains(response, 'hx-push-url="true"')
 
     def test_create_route_is_bound_to_the_active_user_model(self):
         match = resolve(self.get_url())

--- a/bloomerp/django_bloomerp/bloomerp/views/users/create.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/users/create.py
@@ -25,7 +25,7 @@ User = get_user_model()
     models=User
 )
 class UserCreateView(BaseBloomerpView, SuccessMessageMixin, FormView):
-    template_name = "views/generic/detail/create.html"
+    template_name = "views/users/create.html"
     fields = None
     model = User
     exclude = []

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.12.0beta31"
+version = "1.12.0beta32"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## To-do

- ID: `79dc6909-8fdf-45e7-a671-e12def512fa9`
- Title: `[BUG] Create user view functionality not working`

## Root cause

The create-user GET route referenced `views/generic/detail/create.html`, which was deleted during the layout-form refactor. Existing successful POST tests did not render that template, so they did not catch the broken page.

## Changes

- Point the create-user view at a dedicated user creation template.
- Render the password-aware `BloomerpUserCreationForm` with the existing HTMX main-content flow.
- Add a GET regression test covering the username and both password fields.
- Preserve the existing user creation, permissions, authentication, and redirect behavior.

## Validation

- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.views.create_user -v 2` — passed, 6 tests.
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py check` — passed; only the repository's existing third-party model warnings were emitted.
- `git diff --check` — passed.