### PR TITLE
Add ObjectModalAction title and size configuration

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/models/definition.py
+++ b/bloomerp/django_bloomerp/bloomerp/models/definition.py
@@ -269,6 +269,8 @@ class ObjectModalAction(BaseModel):
     should_render_func:Callable[[HttpRequest, Model], bool] = lambda req, obj : True
     
     modal_title:Optional[str] = ""
+
+    modal_size:Literal["sm", "md", "lg", "xl", "full"] = "md"
     
     
 

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/Modal.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/Modal.ts
@@ -8,6 +8,7 @@ const MODAL_PADDING_ATTRIBUTE = 'data-modal-padding'
 const DEFAULT_MODAL_PADDING_ATTRIBUTE = 'data-default-modal-padding'
 const SET_MODAL_TITLE_FOR_ATTRIBUTE = 'bloomerp-set-modal-title-for'
 const SET_MODAL_TITLE_VALUE_ATTRIBUTE = 'bloomerp-set-modal-title-to'
+const SET_MODAL_SIZE_VALUE_ATTRIBUTE = 'bloomerp-set-modal-size-to'
 
 
 /**
@@ -178,6 +179,11 @@ export class Modal extends BaseComponent {
                 const title = (trigger as HTMLElement).getAttribute(SET_MODAL_TITLE_VALUE_ATTRIBUTE);
                 if (title) {
                     this.setTitle(title);
+                }
+
+                const size = (trigger as HTMLElement).getAttribute(SET_MODAL_SIZE_VALUE_ATTRIBUTE);
+                if (size) {
+                    this.setSize(size);
                 }
             });
             (trigger as HTMLElement).setAttribute(this.triggerBoundAttribute, `${this.modalId}:set-title`);

--- a/bloomerp/django_bloomerp/bloomerp/templatetags/bloomerp.py
+++ b/bloomerp/django_bloomerp/bloomerp/templatetags/bloomerp.py
@@ -521,8 +521,9 @@ def render_object_action(
                 '<button class="btn btn-xs btn-{style}" '
                 'hx-get="{url}" '
                 'hx-target="#bloomerp-general-use-modal-body" '
-                'bloomerp-set-modal-title-for="bloomerp-general-use-modal"'
-                'bloomerp-set-modal-title-to="{title}"'
+                'bloomerp-set-modal-title-for="bloomerp-general-use-modal" '
+                'bloomerp-set-modal-title-to="{title}" '
+                'bloomerp-set-modal-size-to="{size}" '
                 'bloomerp-open-modal="bloomerp-general-use-modal">'
                 '{label}'
                 '</button>'
@@ -531,6 +532,7 @@ def render_object_action(
             url=action.endpoint(object),
             label=action.label,
             title=action.modal_title,
+            size=action.modal_size,
         )
 
     if content_type_id is None:


### PR DESCRIPTION
## To-do

- ID: `e56fce22-3558-48ef-9f8c-7a083f965061`
- Title: Addition to ObjectModalAction

## Summary

- Fix the generated ObjectModalAction button markup so modal title and open attributes are emitted separately and work correctly.
- Add a validated `modal_size` option with `sm`, `md`, `lg`, `xl`, and `full` values; it defaults to `md`.
- Apply the configured size through the existing modal component size API whenever the action opens the shared modal.

## Root cause and impact

The generated title/open attributes were concatenated without spaces, producing invalid HTML attributes. Object modal actions can now set their title reliably and opt into a supported modal size while existing actions retain the `md` default.

## Validation

- `npm run type-check` — passed.
- `npm run build:js` — passed (Vite emitted existing dependency and chunk-size warnings only).
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python -m py_compile bloomerp/models/definition.py bloomerp/templatetags/bloomerp.py` — passed.
- Focused Django render assertions for title, open target, default `md`, and custom `xl` attributes — passed.
- `git diff --check` — passed.

## Tests

No automated tests were added because the to-do explicitly requests end-user acceptance testing.