### PR TITLE
Implement detail sidebar view preference functionality

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/components/detail_sidebar_preference.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/detail_sidebar_preference.py
@@ -1,0 +1,23 @@
+from django.contrib.auth.decorators import login_required
+from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.views.decorators.http import require_POST
+
+from bloomerp.models.users.user import DetailSidebarViewPreference
+from bloomerp.router import router
+
+
+@router.register(
+    path="components/detail-sidebar/preference/",
+    name="components_detail_sidebar_preference",
+)
+@login_required
+@require_POST
+def detail_sidebar_preference(request: HttpRequest) -> HttpResponse:
+    """Persist the authenticated user's preferred detail sidebar panel."""
+    view = request.POST.get("view")
+    if view not in DetailSidebarViewPreference.values:
+        return JsonResponse({"status": "error", "error": "Invalid sidebar view."}, status=400)
+
+    request.user.detail_sidebar_view_preference = view
+    request.user.save(update_fields=["detail_sidebar_view_preference"])
+    return JsonResponse({"status": "ok", "view": view})

--- a/bloomerp/django_bloomerp/bloomerp/migrations/0054_user_detail_sidebar_view_preference.py
+++ b/bloomerp/django_bloomerp/bloomerp/migrations/0054_user_detail_sidebar_view_preference.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("bloomerp", "0053_repair_workflow_run_step_schema"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="detail_sidebar_view_preference",
+            field=models.CharField(
+                choices=[("activity", "Activity"), ("comments", "Comments")],
+                default="activity",
+                help_text="The detail view sidebar panel to show first",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/bloomerp/django_bloomerp/bloomerp/models/users/user.py
+++ b/bloomerp/django_bloomerp/bloomerp/models/users/user.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import AbstractUser
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q, QuerySet
 from django.contrib.auth.models import Permission
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from bloomerp.models.base_bloomerp_model import BloomerpModel, FieldLayout, LayoutItem, LayoutRow
 from bloomerp.models.definition import BloomerpModelConfig
 from bloomerp.models.mixins import (
@@ -42,6 +42,33 @@ USER_CONFIG = BloomerpModelConfig(
     ),
 )
 
+
+class DateViewPreference(models.TextChoices):
+    DAY_MONTH_YEAR = "d-m-Y", _("Day-Month-Year (15-08-2000)")
+    MONTH_DAY_YEAR = "m-d-Y", _("Month-Day-Year (08-15-2000)")
+    YEAR_MONTH_DAY = "Y-m-d", _("Year-Month-Day (2000-08-15)")
+
+
+class DatetimeViewPreference(models.TextChoices):
+    DAY_MONTH_YEAR = (
+        "d-m-Y H:i",
+        _("Day-Month-Year Hour:Minute (15-08-2000 12:30)"),
+    )
+    MONTH_DAY_YEAR = (
+        "m-d-Y H:i",
+        _("Month-Day-Year Hour:Minute (08-15-2000 12:30)"),
+    )
+    YEAR_MONTH_DAY = (
+        "Y-m-d H:i",
+        _("Year-Month-Day Hour:Minute (2000-08-15 12:30)"),
+    )
+
+
+class DetailSidebarViewPreference(models.TextChoices):
+    ACTIVITY = "activity", _("Activity")
+    COMMENTS = "comments", _("Comments")
+
+
 class AbstractBloomerpUser(
     AbstractUser, 
     StringSearchModelMixin, 
@@ -53,25 +80,25 @@ class AbstractBloomerpUser(
 
     allow_string_search = True
 
-    DATE_VIEW_PREFERENCE_CHOICES = [
-        ("d-m-Y", "Day-Month-Year (15-08-2000)"),
-        ("m-d-Y", "Month-Day-Year (08-15-2000)"),
-        ("Y-m-d", "Year-Month-Day (2000-08-15)"),
-    ]
-
-    DATETIME_VIEW_PREFERENCE_CHOICES = [
-        ("d-m-Y H:i", "Day-Month-Year Hour:Minute (15-08-2000 12:30)"),
-        ("m-d-Y H:i", "Month-Day-Year Hour:Minute (08-15-2000 12:30)"),
-        ("Y-m-d H:i", "Year-Month-Day Hour:Minute (2000-08-15 12:30)"),
-    ]
-
-
     date_view_preference = models.CharField(
-        max_length=20, default="d-m-Y", choices=DATE_VIEW_PREFERENCE_CHOICES, help_text=_("The date format to be used in the application")
+        max_length=20,
+        default=DateViewPreference.DAY_MONTH_YEAR,
+        choices=DateViewPreference.choices,
+        help_text=_("The date format to be used in the application"),
     )
 
     datetime_view_preference = models.CharField(
-        max_length=20, default="d-m-Y H:i", choices=DATETIME_VIEW_PREFERENCE_CHOICES, help_text=_("The datetime format to be used in the application")
+        max_length=20,
+        default=DatetimeViewPreference.DAY_MONTH_YEAR,
+        choices=DatetimeViewPreference.choices,
+        help_text=_("The datetime format to be used in the application"),
+    )
+
+    detail_sidebar_view_preference = models.CharField(
+        max_length=20,
+        default=DetailSidebarViewPreference.ACTIVITY,
+        choices=DetailSidebarViewPreference.choices,
+        help_text=_("The detail view sidebar panel to show first"),
     )
     
     def __str__(self):

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/detail_view_components/DetailViewFrame.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/detail_view_components/DetailViewFrame.ts
@@ -1,4 +1,5 @@
 import BaseComponent from "../BaseComponent";
+import { getCsrfToken } from "../../utils/cookies";
 
 const MAIN_SELECTOR = "#main";
 const DESKTOP_MEDIA_QUERY = "(min-width: 1280px)";
@@ -6,9 +7,13 @@ const DESKTOP_MEDIA_QUERY = "(min-width: 1280px)";
 export default class DetailViewFrame extends BaseComponent {
     private resizeHandler: (() => void) | null = null;
     private resizeObserver: ResizeObserver | null = null;
+    private sidebarPreferenceSaveQueue: Promise<void> = Promise.resolve();
+    private readonly sidebarClickHandler = (event: Event) => this.saveSidebarView(event);
 
     public initialize(): void {
         if (!this.element) return;
+
+        this.element.addEventListener("click", this.sidebarClickHandler);
 
         this.resizeHandler = () => this.fitToMainBottom();
         window.addEventListener("resize", this.resizeHandler);
@@ -19,6 +24,8 @@ export default class DetailViewFrame extends BaseComponent {
     }
 
     public destroy(): void {
+        this.element?.removeEventListener("click", this.sidebarClickHandler);
+
         if (this.resizeHandler) {
             window.removeEventListener("resize", this.resizeHandler);
             window.visualViewport?.removeEventListener("resize", this.resizeHandler);
@@ -28,6 +35,33 @@ export default class DetailViewFrame extends BaseComponent {
         this.resizeHandler = null;
         this.resizeObserver = null;
         super.destroy();
+    }
+
+    private saveSidebarView(event: Event): void {
+        const target = event.target as HTMLElement | null;
+        const button = target?.closest<HTMLElement>("[data-detail-sidebar-view]");
+        const saveUrl = this.element?.dataset.sidebarPreferenceUrl;
+        const view = button?.dataset.detailSidebarView;
+
+        if (!button || !saveUrl || !view) return;
+
+        this.sidebarPreferenceSaveQueue = this.sidebarPreferenceSaveQueue
+            .then(async () => {
+                const csrfToken = getCsrfToken();
+                const response = await fetch(saveUrl, {
+                    method: "POST",
+                    credentials: "same-origin",
+                    headers: csrfToken ? { "X-CSRFToken": csrfToken } : {},
+                    body: new URLSearchParams({ view }),
+                });
+
+                if (!response.ok) {
+                    throw new Error(`Preference request failed with status ${response.status}.`);
+                }
+            })
+            .catch((error: unknown) => {
+                console.error("Unable to save the detail sidebar preference.", error);
+            });
     }
 
     public onAfterSwap(): void {

--- a/bloomerp/django_bloomerp/bloomerp/templates/views/generic/detail/base.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/views/generic/detail/base.html
@@ -7,6 +7,7 @@
 	bloomerp-component="detail-view-frame"
 	class="grid gap-6 xl:h-full xl:min-h-0 xl:overflow-hidden xl:gap-0 {% if include_detail_aside %}xl:grid-cols-[minmax(0,1fr)_minmax(16rem,20rem)_auto]{% else %}xl:grid-cols-[minmax(0,1fr)_auto]{% endif %}"
 	data-detail-view-grid
+	data-sidebar-preference-url="{% url 'components_detail_sidebar_preference' %}"
 >
 
 	<section class="min-w-0 xl:h-full xl:min-h-0 xl:overflow-hidden">
@@ -123,6 +124,7 @@
 					<div class="flex flex-wrap justify-center gap-2">
 						<button 
 							class="btn btn-secondary btn-sm"
+							data-detail-sidebar-view="activity"
 							hx-get="{% url 'components_activity_log' %}?content_type_id={{ content_type_id }}&object_id={{ object.id }}"
 							hx-target="#object-sidesection"
 							hx-animation	
@@ -132,6 +134,7 @@
 						</button>
 						<button 
 							class="btn btn-secondary btn-sm"
+							data-detail-sidebar-view="comments"
 							hx-get="{% url 'components_comments' content_type_id=content_type_id object_id=object.id %}"
 							hx-target="#object-sidesection"
 							hx-animation	
@@ -158,7 +161,8 @@
 						{% endfor %}
 					</div>
 					<div
-						hx-get="{% url 'components_activity_log' %}?content_type_id={{ content_type_id }}&object_id={{ object.id }}" 
+						data-detail-sidebar-loader
+						hx-get="{% if detail_sidebar_view == 'comments' %}{% url 'components_comments' content_type_id=content_type_id object_id=object.id %}{% else %}{% url 'components_activity_log' %}?content_type_id={{ content_type_id }}&object_id={{ object.id }}{% endif %}"
 						hx-target="#object-sidesection" 
 						hx-trigger="load"
 						hx-swap="innerHTML"

--- a/bloomerp/django_bloomerp/bloomerp/tests/components/test_detail_sidebar_preference.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/components/test_detail_sidebar_preference.py
@@ -1,0 +1,138 @@
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from bloomerp.models import User
+from bloomerp.models.users.user import DetailSidebarViewPreference
+
+
+class DetailSidebarPreferenceComponentTests(TestCase):
+    def setUp(self) -> None:
+        self.user = User.objects.create_user(
+            username="detail-sidebar-user",
+            password="testpass123",
+        )
+        self.url = reverse("components_detail_sidebar_preference")
+
+    def test_user_defaults_to_activity_as_the_first_sidebar_panel(self):
+        """
+        Use case: A user has not selected a detail sidebar panel.
+        Expected result: Activity is stored as the default preference.
+        """
+        # 1. Read the newly created user's sidebar preference.
+        preference = self.user.detail_sidebar_view_preference
+
+        # 2. Confirm the existing Activity-first behavior is preserved.
+        self.assertEqual(preference, DetailSidebarViewPreference.ACTIVITY)
+
+    def test_user_can_persist_comments_as_the_first_sidebar_panel(self):
+        """
+        Use case: A user selects Comments in a detail view sidebar.
+        Expected result: The user's preference is saved for future detail views.
+        """
+        # 1. Authenticate as the user selecting the panel.
+        self.client.force_login(self.user)
+
+        # 2. Persist the Comments selection.
+        response = self.client.post(self.url, {"view": "comments"})
+
+        # 3. Confirm the response and stored preference.
+        self.assertEqual(response.status_code, 200)
+        self.assertJSONEqual(response.content, {"status": "ok", "view": "comments"})
+        self.user.refresh_from_db()
+        self.assertEqual(
+            self.user.detail_sidebar_view_preference,
+            DetailSidebarViewPreference.COMMENTS,
+        )
+
+    def test_user_can_switch_the_first_sidebar_panel_back_to_activity(self):
+        """
+        Use case: A user selects Activity after previously selecting Comments.
+        Expected result: Activity becomes the persisted sidebar preference.
+        """
+        # 1. Give the user an existing Comments preference and authenticate them.
+        self.user.detail_sidebar_view_preference = DetailSidebarViewPreference.COMMENTS
+        self.user.save(update_fields=["detail_sidebar_view_preference"])
+        self.client.force_login(self.user)
+
+        # 2. Persist the Activity selection.
+        response = self.client.post(
+            self.url,
+            {"view": DetailSidebarViewPreference.ACTIVITY},
+        )
+
+        # 3. Confirm the latest selection replaces the previous preference.
+        self.assertEqual(response.status_code, 200)
+        self.user.refresh_from_db()
+        self.assertEqual(
+            self.user.detail_sidebar_view_preference,
+            DetailSidebarViewPreference.ACTIVITY,
+        )
+
+    def test_invalid_sidebar_panel_is_rejected(self):
+        """
+        Use case: A client submits an unsupported detail sidebar panel.
+        Expected result: The preference remains at the Activity default.
+        """
+        # 1. Authenticate as the user.
+        self.client.force_login(self.user)
+
+        # 2. Submit an unsupported panel value.
+        response = self.client.post(self.url, {"view": "unsupported"})
+
+        # 3. Confirm validation prevents a preference change.
+        self.assertEqual(response.status_code, 400)
+        self.user.refresh_from_db()
+        self.assertEqual(
+            self.user.detail_sidebar_view_preference,
+            DetailSidebarViewPreference.ACTIVITY,
+        )
+
+    def test_sidebar_preference_requires_authentication(self):
+        """
+        Use case: An anonymous client tries to change a sidebar preference.
+        Expected result: Authentication is required and no user preference changes.
+        """
+        # 1. Submit a preference without authenticating.
+        response = self.client.post(self.url, {"view": "comments"})
+
+        # 2. Confirm the request is redirected to authentication.
+        self.assertEqual(response.status_code, 302)
+        self.user.refresh_from_db()
+        self.assertEqual(
+            self.user.detail_sidebar_view_preference,
+            DetailSidebarViewPreference.ACTIVITY,
+        )
+
+    def test_sidebar_preference_requires_csrf_token(self):
+        """
+        Use case: An authenticated client submits a preference without a CSRF token.
+        Expected result: Django rejects the update.
+        """
+        # 1. Authenticate with a client that enforces CSRF validation.
+        csrf_client = Client(enforce_csrf_checks=True)
+        csrf_client.force_login(self.user)
+
+        # 2. Submit the preference without a CSRF token.
+        response = csrf_client.post(self.url, {"view": "comments"})
+
+        # 3. Confirm the request is forbidden and the preference is unchanged.
+        self.assertEqual(response.status_code, 403)
+        self.user.refresh_from_db()
+        self.assertEqual(
+            self.user.detail_sidebar_view_preference,
+            DetailSidebarViewPreference.ACTIVITY,
+        )
+
+    def test_sidebar_preference_requires_post(self):
+        """
+        Use case: A client tries to read the preference endpoint directly.
+        Expected result: The endpoint only accepts preference updates.
+        """
+        # 1. Authenticate as the user.
+        self.client.force_login(self.user)
+
+        # 2. Use an unsupported request method.
+        response = self.client.get(self.url)
+
+        # 3. Confirm the endpoint rejects the request.
+        self.assertEqual(response.status_code, 405)

--- a/bloomerp/django_bloomerp/bloomerp/tests/views/overview.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/views/overview.py
@@ -1,5 +1,6 @@
 import json
 
+from bs4 import BeautifulSoup
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -15,6 +16,7 @@ from bloomerp.models import (
     File,
 )
 from bloomerp.models.project_management import Initiative, Todo
+from bloomerp.models.users.user import DetailSidebarViewPreference
 from bloomerp.models.workspaces.sidebar import Sidebar
 from bloomerp.tests.views.crud_test_mixin import CrudViewTestMixin
 
@@ -239,6 +241,59 @@ class TestOverviewView(CrudViewTestMixin):
         # 3. Verify the create-todo action is still rendered.
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "/components/todo/create-todo-for-object/", html=False)
+
+    def test_customer_detail_uses_persisted_sidebar_preference(self):
+        """
+        Use case: A user previously selected Comments in a detail view sidebar.
+        Expected result: The detail view loads Comments before Activity.
+        """
+        # 1. Persist the user's preferred sidebar panel.
+        self.admin_user.detail_sidebar_view_preference = (
+            DetailSidebarViewPreference.COMMENTS
+        )
+        self.admin_user.save(update_fields=["detail_sidebar_view_preference"])
+        self.client.force_login(self.admin_user)
+
+        # 2. Render the customer detail page.
+        response = self.client.get(self.get_url())
+
+        # 3. Verify the initial sidebar request targets Comments.
+        comments_url = reverse(
+            "components_comments",
+            kwargs={
+                "content_type_id": self.content_type.pk,
+                "object_id": self.customer.pk,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        sidebar_loader = BeautifulSoup(response.content, "html.parser").select_one(
+            "[data-detail-sidebar-loader]"
+        )
+        self.assertIsNotNone(sidebar_loader)
+        self.assertEqual(sidebar_loader.get("hx-get"), comments_url)
+
+    def test_customer_detail_defaults_to_activity_sidebar(self):
+        """
+        Use case: A user has not selected a detail sidebar panel.
+        Expected result: The detail view initially loads Activity.
+        """
+        # 1. Authenticate as a user with the default sidebar preference.
+        self.client.force_login(self.admin_user)
+
+        # 2. Render the customer detail page.
+        response = self.client.get(self.get_url())
+
+        # 3. Verify the load-on-render container targets Activity specifically.
+        activity_url = (
+            f'{reverse("components_activity_log")}'
+            f"?content_type_id={self.content_type.pk}&object_id={self.customer.pk}"
+        )
+        sidebar_loader = BeautifulSoup(response.content, "html.parser").select_one(
+            "[data-detail-sidebar-loader]"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIsNotNone(sidebar_loader)
+        self.assertEqual(sidebar_loader.get("hx-get"), activity_url)
 
     def test_todo_detail_hides_create_todo_button(self):
         """

--- a/bloomerp/django_bloomerp/bloomerp/views/generic/detail/base.py
+++ b/bloomerp/django_bloomerp/bloomerp/views/generic/detail/base.py
@@ -104,6 +104,7 @@ class BaseBloomerpDetailView(BaseBloomerpView, BloomerpModelContextMixin, Detail
             
         content_type = ContentType.objects.get_for_model(self.model)
         context["detail_view_content_type_id"] = content_type.pk
+        context["detail_sidebar_view"] = self.request.user.detail_sidebar_view_preference
         context["can_change_avatar"] = self._can_change_avatar(content_type)
         tabs_preference = self.detail_tabs_preference
         preference_manager = PreferenceManager(self.request.user)


### PR DESCRIPTION
- Add a new model field for user detail sidebar view preference.
- Create a view to persist the user's preferred sidebar panel.
- Update the detail view to load the user's sidebar preference.
- Enhance the frontend to handle sidebar view changes and save preferences.
- Add tests to ensure correct behavior of sidebar preference persistence.