### PR TITLE
Add configurable default model detail tabs

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/models/definition.py
+++ b/bloomerp/django_bloomerp/bloomerp/models/definition.py
@@ -8,7 +8,14 @@ from django.http import HttpRequest, HttpResponse
 from bloomerp.config.definition import BloomerpConfig
 from bloomerp.field_types.lookups import Lookup
 from bloomerp.workspaces.base import BaseTileConfig
-from pydantic import BaseModel, ConfigDict, Field, SerializeAsAny, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    SerializeAsAny,
+    field_validator,
+    model_validator,
+)
 from django.conf import settings
 from django.db.models import Model
 
@@ -60,6 +67,9 @@ class WorkspaceLayout(BaseLayout):
     pass
 
 
+# ----------------------------------
+# DETAIL TABS CONFIGURATION
+# ----------------------------------
 DETAIL_TAB_TEMPLATE_ARGUMENT = re.compile(r"{{\s*([^{}]+?)\s*}}")
 
 
@@ -96,7 +106,8 @@ class DetailTab(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name: str = Field(min_length=1, max_length=255)
-    url: str = Field(min_length=1, max_length=2048)
+    url: str | None = Field(default=None, min_length=1, max_length=2048)
+    url_name: str | None = Field(default=None, min_length=1, max_length=255)
 
     @field_validator("name")
     @classmethod
@@ -108,8 +119,24 @@ class DetailTab(BaseModel):
 
     @field_validator("url")
     @classmethod
-    def validate_url(cls, value: str) -> str:
-        return validate_detail_tab_url(value)
+    def validate_url(cls, value: str | None) -> str | None:
+        return validate_detail_tab_url(value) if value is not None else None
+
+    @field_validator("url_name")
+    @classmethod
+    def normalize_url_name(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("URL name is required.")
+        return normalized
+
+    @model_validator(mode="after")
+    def validate_url_source(self) -> "DetailTab":
+        if (self.url is None) == (self.url_name is None):
+            raise ValueError("Provide exactly one of url or url_name.")
+        return self
 
 
 class DetailTabFolder(BaseModel):
@@ -119,6 +146,23 @@ class DetailTabFolder(BaseModel):
 
     name: str = Field(min_length=1, max_length=255)
     tabs: list[DetailTab] = Field(default_factory=list)
+
+    @field_validator("name")
+    @classmethod
+    def normalize_name(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Name is required.")
+        return normalized
+
+
+class DetailTabsConfiguration(BaseModel):
+    """A collection of declarative tabs shown on a model's detail view."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(default="Default", min_length=1, max_length=255)
+    tabs: list[DetailTab | DetailTabFolder] = Field(default_factory=list)
 
     @field_validator("name")
     @classmethod
@@ -157,6 +201,7 @@ class ApiFilterRule(BaseModel):
             if operator_value == lookup.value.id:
                 return lookup.value.django_representation or operator_value
         return operator_value
+
 
 class PublicAccessRule(BaseModel):
     """A public access rule defines in which cases objects can be accessed via the
@@ -240,6 +285,7 @@ class PublicAccessRule(BaseModel):
             ):
                 allowed_fields.add(field_name)
         return allowed_fields
+
 
 class UserAccessRule(BaseModel):
     """A user access rule defines in which cases users can access an object via the api. The through field serves as the entry point for the user access definition. Note that user access rules only apply to the auto generated API's.
@@ -413,13 +459,14 @@ class ModelViewSettings(BaseModel):
 class DetailViewSettings(BaseModel):
     """Settings regarding detail views for a model.
 
-    ``default_tabs=None`` retains router-derived defaults, while an explicit
-    list (including an empty list) replaces those defaults for new users.
+    An empty ``tab_configurations`` list retains router-derived defaults. Each
+    configured layout becomes a named preference, with the first one selected.
     """
 
-    skip_views : Optional[list[str]] = None
-    default_tabs: list[DetailTab | DetailTabFolder] | None = None
-    
+    skip_views: Optional[list[str]] = None
+    tab_configurations: list[DetailTabsConfiguration] = Field(default_factory=list)
+
+
 class BloomerpModelConfig(BaseModel):
     """
     Used to define certain bloomerp related meta data on a model. 

--- a/bloomerp/django_bloomerp/bloomerp/models/definition.py
+++ b/bloomerp/django_bloomerp/bloomerp/models/definition.py
@@ -1,12 +1,14 @@
 import json
 import inspect
+import re
 from typing import Any, Callable, Literal, Optional, Type
+from urllib.parse import urlsplit
 
 from django.http import HttpRequest, HttpResponse
 from bloomerp.config.definition import BloomerpConfig
 from bloomerp.field_types.lookups import Lookup
 from bloomerp.workspaces.base import BaseTileConfig
-from pydantic import BaseModel, Field, SerializeAsAny, field_validator
+from pydantic import BaseModel, ConfigDict, Field, SerializeAsAny, field_validator
 from django.conf import settings
 from django.db.models import Model
 
@@ -56,6 +58,75 @@ class FieldLayout(BaseLayout):
 
 class WorkspaceLayout(BaseLayout):
     pass
+
+
+DETAIL_TAB_TEMPLATE_ARGUMENT = re.compile(r"{{\s*([^{}]+?)\s*}}")
+
+
+def validate_detail_tab_url(url: str) -> str:
+    """Validate and normalize a declarative detail-tab URL template."""
+    normalized = url.strip()
+    if not normalized:
+        raise ValueError("URL is required.")
+
+    arguments = {
+        argument.strip()
+        for argument in DETAIL_TAB_TEMPLATE_ARGUMENT.findall(normalized)
+    }
+    if arguments - {"pk"}:
+        raise ValueError("Only the {{pk}} placeholder is supported.")
+
+    parsed = urlsplit(normalized)
+    is_internal = (
+        not parsed.scheme
+        and not parsed.netloc
+        and normalized.startswith("/")
+    )
+    is_external = parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+    if not is_internal and not is_external:
+        raise ValueError(
+            "Enter an internal URL beginning with / or a complete http(s) URL."
+        )
+    return normalized
+
+
+class DetailTab(BaseModel):
+    """A declarative tab shown on a model's detail view."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=255)
+    url: str = Field(min_length=1, max_length=2048)
+
+    @field_validator("name")
+    @classmethod
+    def normalize_name(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Name is required.")
+        return normalized
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, value: str) -> str:
+        return validate_detail_tab_url(value)
+
+
+class DetailTabFolder(BaseModel):
+    """A top-level folder containing declarative detail tabs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1, max_length=255)
+    tabs: list[DetailTab] = Field(default_factory=list)
+
+    @field_validator("name")
+    @classmethod
+    def normalize_name(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Name is required.")
+        return normalized
 
 
 def validate_declarative_tile_configs(
@@ -340,10 +411,14 @@ class ModelViewSettings(BaseModel):
     skip_views : Optional[list[str]] = None
 
 class DetailViewSettings(BaseModel):
+    """Settings regarding detail views for a model.
+
+    ``default_tabs=None`` retains router-derived defaults, while an explicit
+    list (including an empty list) replaces those defaults for new users.
     """
-    Settings regarding detail views for certain models
-    """
+
     skip_views : Optional[list[str]] = None
+    default_tabs: list[DetailTab | DetailTabFolder] | None = None
     
 class BloomerpModelConfig(BaseModel):
     """

--- a/bloomerp/django_bloomerp/bloomerp/models/project_management/todo.py
+++ b/bloomerp/django_bloomerp/bloomerp/models/project_management/todo.py
@@ -11,7 +11,14 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.core.exceptions import ValidationError
 
 from bloomerp.models.base_bloomerp_model import FieldLayout, LayoutItem, LayoutRow
-from bloomerp.models.definition import BloomerpModelConfig, ObjectAction, ObjectHTML
+from bloomerp.models.definition import (
+    BloomerpModelConfig,
+    DetailTab,
+    DetailTabsConfiguration,
+    DetailViewSettings,
+    ObjectAction,
+    ObjectHTML,
+)
 from bloomerp.utils.models import get_list_view_url
 from bloomerp.workspaces.analytics_tile.model import AnalyticsTileFilter, FieldConfig
 from bloomerp.permissions.definition import BloomerpPermission
@@ -132,6 +139,19 @@ class Todo(BloomerpModel):
                 execution_func=_mark_as_completed
             )
         ],
+        detail_view_settings=DetailViewSettings(
+            tab_configurations=[
+                DetailTabsConfiguration(
+                    name="Default",
+                    tabs=[
+                        DetailTab(
+                            name="Overview",
+                            url_name="todos_detail_overview",
+                        )
+                    ],
+                )
+            ]
+        ),
         tiles=[
             AnalyticsTileConfig(
                 type=AnalyticsTileType.KPI.value.key,

--- a/bloomerp/django_bloomerp/bloomerp/models/users/user_detail_view_tabs_preference.py
+++ b/bloomerp/django_bloomerp/bloomerp/models/users/user_detail_view_tabs_preference.py
@@ -17,6 +17,7 @@ from bloomerp.models.definition import (
     BloomerpModelConfig,
     DetailTab,
     DetailTabFolder,
+    DetailTabsConfiguration,
     UserAccessRule,
     get_model_config,
     validate_detail_tab_url,
@@ -83,12 +84,33 @@ class UserDetailViewTabsPreference(BasePreference):
         **scope,
     ) -> "UserDetailViewTabsPreference":
         """Create and populate the default detail-tab layout for a model."""
+        content_type = ContentType.objects.get_for_id(scope["content_type_id"])
+        model = content_type.model_class()
+        model_config = get_model_config(model) if model is not None else None
+        detail_view_settings = (
+            model_config.detail_view_settings if model_config is not None else None
+        )
+        tab_configurations = (
+            detail_view_settings.tab_configurations
+            if detail_view_settings is not None
+            else []
+        )
+
+        if tab_configurations:
+            return cls.create_configured_defaults(
+                user=user,
+                content_type=content_type,
+                model=model,
+                configurations=tab_configurations,
+            )
+
         with transaction.atomic():
             preference = cls.objects.create(
                 user=user,
-                content_type_id=scope["content_type_id"],
+                content_type=content_type,
+                selected=True,
             )
-            preference.create_default_items()
+            preference.create_router_default_items(model)
         return preference
 
     @classmethod
@@ -163,20 +185,8 @@ class UserDetailViewTabsPreference(BasePreference):
         """Resolve the supported object placeholder in a stored tab URL."""
         return url.replace("{{pk}}", str(object_pk))
 
-    def create_default_items(self) -> None:
+    def create_router_default_items(self, model: type[models.Model] | None) -> None:
         """Populate default routes and group relationship routes in one folder."""
-        model = self.content_type.model_class()
-        model_config = get_model_config(model) if model is not None else None
-        detail_view_settings = (
-            model_config.detail_view_settings if model_config is not None else None
-        )
-        if (
-            detail_view_settings is not None
-            and detail_view_settings.default_tabs is not None
-        ):
-            self.create_configured_default_items(detail_view_settings.default_tabs)
-            return
-
         options = self.get_detail_route_options(model)
         relationship_options = [
             option for option in options if option["is_relationship"]
@@ -222,13 +232,68 @@ class UserDetailViewTabsPreference(BasePreference):
                     position=position,
                 )
 
+    @classmethod
+    def create_configured_defaults(
+        cls,
+        *,
+        user: Any,
+        content_type: ContentType,
+        model: type[models.Model] | None,
+        configurations: list[DetailTabsConfiguration],
+    ) -> "UserDetailViewTabsPreference":
+        """Materialize every named model configuration for a new user."""
+        selected_preference: UserDetailViewTabsPreference | None = None
+        with transaction.atomic():
+            for position, configuration in enumerate(configurations):
+                preference = cls.objects.create(
+                    user=user,
+                    content_type=content_type,
+                    name=configuration.name,
+                    selected=position == 0,
+                )
+                preference.create_configured_default_items(
+                    configuration.tabs,
+                    model=model,
+                )
+                if position == 0:
+                    selected_preference = preference
+
+        if selected_preference is None:
+            raise ValueError("At least one tab configuration is required.")
+        return selected_preference
+
+    @staticmethod
+    def get_configured_tab_url(
+        tab: DetailTab,
+        model: type[models.Model] | None,
+    ) -> str:
+        """Return a URL template from a literal URL or a model detail route name."""
+        if tab.url is not None:
+            return tab.url
+        if model is None:
+            raise ValueError(f"Cannot resolve detail tab URL name '{tab.url_name}'.")
+
+        for route in router.filter(model=model, route_type="detail"):
+            if route.url_name != tab.url_name:
+                continue
+            if route.nr_of_args() != 1 or not PK_ROUTE_ARGUMENT.search(route.path):
+                break
+            return PK_ROUTE_ARGUMENT.sub("{{pk}}", route.path)
+
+        raise ValueError(
+            f"Detail tab URL name '{tab.url_name}' must identify a one-PK "
+            f"detail route for {model.__name__}."
+        )
+
     def create_configured_default_items(
         self,
-        default_tabs: list[DetailTab | DetailTabFolder],
+        tabs: list[DetailTab | DetailTabFolder],
+        *,
+        model: type[models.Model] | None,
     ) -> None:
         """Materialize the model's declarative default tab layout."""
         with transaction.atomic():
-            for position, item in enumerate(default_tabs):
+            for position, item in enumerate(tabs):
                 if isinstance(item, DetailTabFolder):
                     folder = UserDetailViewTabItem.objects.create(
                         preference=self,
@@ -242,7 +307,7 @@ class UserDetailViewTabsPreference(BasePreference):
                                 preference=self,
                                 parent=folder,
                                 name=tab.name,
-                                url=tab.url,
+                                url=self.get_configured_tab_url(tab, model),
                                 position=child_position,
                             )
                             for child_position, tab in enumerate(item.tabs)
@@ -253,7 +318,7 @@ class UserDetailViewTabsPreference(BasePreference):
                 UserDetailViewTabItem.objects.create(
                     preference=self,
                     name=item.name,
-                    url=item.url,
+                    url=self.get_configured_tab_url(item, model),
                     position=position,
                 )
 

--- a/bloomerp/django_bloomerp/bloomerp/models/users/user_detail_view_tabs_preference.py
+++ b/bloomerp/django_bloomerp/bloomerp/models/users/user_detail_view_tabs_preference.py
@@ -15,14 +15,17 @@ from django.db.models import Q
 from bloomerp.models.definition import (
     ApiSettings,
     BloomerpModelConfig,
+    DetailTab,
+    DetailTabFolder,
     UserAccessRule,
+    get_model_config,
+    validate_detail_tab_url,
 )
 from bloomerp.models.users.base_preference import BasePreference
 from bloomerp.router import router
 
 
 PK_ROUTE_ARGUMENT = re.compile(r"<(?:[^:>]+:)?pk>")
-TEMPLATE_ARGUMENT = re.compile(r"{{\s*([^{}]+?)\s*}}")
 MAX_TAB_ITEMS = 250
 RELATIONSHIPS_FOLDER_NAME = "Relationships"
 
@@ -150,29 +153,10 @@ class UserDetailViewTabsPreference(BasePreference):
     @staticmethod
     def validate_tab_url(url: str) -> str:
         """Validate a root-relative or HTTP(S) URL using only ``{{pk}}``."""
-        normalized = url.strip()
-        if not normalized:
-            raise ValidationError("URL is required.")
-
-        arguments = {
-            argument.strip()
-            for argument in TEMPLATE_ARGUMENT.findall(normalized)
-        }
-        if arguments - {"pk"}:
-            raise ValidationError("Only the {{pk}} placeholder is supported.")
-
-        parsed = urlsplit(normalized)
-        is_internal = (
-            not parsed.scheme
-            and not parsed.netloc
-            and normalized.startswith("/")
-        )
-        is_external = parsed.scheme in {"http", "https"} and bool(parsed.netloc)
-        if not is_internal and not is_external:
-            raise ValidationError(
-                "Enter an internal URL beginning with / or a complete http(s) URL."
-            )
-        return normalized
+        try:
+            return validate_detail_tab_url(url)
+        except ValueError as exc:
+            raise ValidationError(str(exc)) from exc
 
     @staticmethod
     def resolve_tab_url(url: str, object_pk: Any) -> str:
@@ -181,7 +165,19 @@ class UserDetailViewTabsPreference(BasePreference):
 
     def create_default_items(self) -> None:
         """Populate default routes and group relationship routes in one folder."""
-        options = self.get_detail_route_options(self.content_type.model_class())
+        model = self.content_type.model_class()
+        model_config = get_model_config(model) if model is not None else None
+        detail_view_settings = (
+            model_config.detail_view_settings if model_config is not None else None
+        )
+        if (
+            detail_view_settings is not None
+            and detail_view_settings.default_tabs is not None
+        ):
+            self.create_configured_default_items(detail_view_settings.default_tabs)
+            return
+
+        options = self.get_detail_route_options(model)
         relationship_options = [
             option for option in options if option["is_relationship"]
         ]
@@ -223,6 +219,41 @@ class UserDetailViewTabsPreference(BasePreference):
                     preference=self,
                     name=option["name"],
                     url=option["url"],
+                    position=position,
+                )
+
+    def create_configured_default_items(
+        self,
+        default_tabs: list[DetailTab | DetailTabFolder],
+    ) -> None:
+        """Materialize the model's declarative default tab layout."""
+        with transaction.atomic():
+            for position, item in enumerate(default_tabs):
+                if isinstance(item, DetailTabFolder):
+                    folder = UserDetailViewTabItem.objects.create(
+                        preference=self,
+                        name=item.name,
+                        url=None,
+                        position=position,
+                    )
+                    UserDetailViewTabItem.objects.bulk_create(
+                        [
+                            UserDetailViewTabItem(
+                                preference=self,
+                                parent=folder,
+                                name=tab.name,
+                                url=tab.url,
+                                position=child_position,
+                            )
+                            for child_position, tab in enumerate(item.tabs)
+                        ]
+                    )
+                    continue
+
+                UserDetailViewTabItem.objects.create(
+                    preference=self,
+                    name=item.name,
+                    url=item.url,
                     position=position,
                 )
 

--- a/bloomerp/django_bloomerp/bloomerp/tests/models/test_model_definition.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/models/test_model_definition.py
@@ -1,7 +1,12 @@
 from django.test import SimpleTestCase
 from pydantic import ValidationError
 
-from bloomerp.models.definition import BloomerpModelConfig
+from bloomerp.models.definition import (
+    BloomerpModelConfig,
+    DetailTab,
+    DetailTabFolder,
+    DetailViewSettings,
+)
 from bloomerp.workspaces.text_tile.model import TextTileConfig
 
 
@@ -62,5 +67,67 @@ class BloomerpModelConfigTileTests(SimpleTestCase):
                 tiles=[
                     TextTileConfig(id="summary", markdown="First"),
                     TextTileConfig(id="summary", markdown="Second"),
+                ]
+            )
+
+
+class DetailViewSettingsTests(SimpleTestCase):
+    def test_detail_view_settings_accept_declarative_default_tabs(self):
+        """
+        Use case: A model declares an ordered default detail-tab layout.
+        Expected result: Tabs and folders retain their concrete types and payloads.
+        """
+        # 1. Define a default layout with a top-level tab and folder.
+        settings = DetailViewSettings(
+            default_tabs=[
+                DetailTab(name=" Overview ", url=" /todos/{{pk}}/ "),
+                DetailTabFolder(
+                    name="Related",
+                    tabs=[
+                        DetailTab(
+                            name="Initiative",
+                            url="/todos/{{pk}}/initiative/",
+                        )
+                    ],
+                ),
+            ]
+        )
+
+        # 2. Confirm normalization and the easy-to-consume concrete models.
+        self.assertEqual(settings.default_tabs[0].name, "Overview")
+        self.assertEqual(settings.default_tabs[0].url, "/todos/{{pk}}/")
+        self.assertIsInstance(settings.default_tabs[1], DetailTabFolder)
+        self.assertEqual(settings.default_tabs[1].tabs[0].name, "Initiative")
+
+        # 3. Confirm absent and explicitly empty overrides remain distinguishable.
+        self.assertIsNone(DetailViewSettings().default_tabs)
+        self.assertEqual(DetailViewSettings(default_tabs=[]).default_tabs, [])
+
+    def test_detail_view_settings_reject_invalid_default_tabs(self):
+        """
+        Use case: A model declares malformed default tabs or nested folders.
+        Expected result: Configuration validation fails during application startup.
+        """
+        # 1. Reject unsupported URL templates.
+        with self.assertRaisesRegex(ValidationError, "Only the.*pk.*placeholder"):
+            DetailViewSettings(
+                default_tabs=[
+                    DetailTab(name="Invalid", url="/todos/{{user_id}}/")
+                ]
+            )
+
+        # 2. Reject folders inside folders through the concrete child type.
+        with self.assertRaises(ValidationError):
+            DetailViewSettings(
+                default_tabs=[
+                    {
+                        "name": "Parent",
+                        "tabs": [
+                            {
+                                "name": "Nested",
+                                "tabs": [],
+                            }
+                        ],
+                    }
                 ]
             )

--- a/bloomerp/django_bloomerp/bloomerp/tests/models/test_model_definition.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/models/test_model_definition.py
@@ -5,6 +5,7 @@ from bloomerp.models.definition import (
     BloomerpModelConfig,
     DetailTab,
     DetailTabFolder,
+    DetailTabsConfiguration,
     DetailViewSettings,
 )
 from bloomerp.workspaces.text_tile.model import TextTileConfig
@@ -72,38 +73,49 @@ class BloomerpModelConfigTileTests(SimpleTestCase):
 
 
 class DetailViewSettingsTests(SimpleTestCase):
-    def test_detail_view_settings_accept_declarative_default_tabs(self):
+    def test_detail_view_settings_accept_named_tab_configurations(self):
         """
-        Use case: A model declares an ordered default detail-tab layout.
-        Expected result: Tabs and folders retain their concrete types and payloads.
+        Use case: A model declares multiple named detail-tab configurations.
+        Expected result: Names, URL targets, folders, and ordering retain their payloads.
         """
-        # 1. Define a default layout with a top-level tab and folder.
+        # 1. Define named layouts using literal URLs and a route name.
         settings = DetailViewSettings(
-            default_tabs=[
-                DetailTab(name=" Overview ", url=" /todos/{{pk}}/ "),
-                DetailTabFolder(
-                    name="Related",
+            tab_configurations=[
+                DetailTabsConfiguration(
+                    name=" Primary ",
                     tabs=[
                         DetailTab(
-                            name="Initiative",
-                            url="/todos/{{pk}}/initiative/",
-                        )
+                            name=" Overview ",
+                            url_name=" todos_detail_overview ",
+                        ),
+                        DetailTabFolder(
+                            name="Related",
+                            tabs=[
+                                DetailTab(
+                                    name="Initiative",
+                                    url="/todos/{{pk}}/initiative/",
+                                )
+                            ],
+                        ),
                     ],
                 ),
+                DetailTabsConfiguration(name="Empty", tabs=[]),
             ]
         )
 
         # 2. Confirm normalization and the easy-to-consume concrete models.
-        self.assertEqual(settings.default_tabs[0].name, "Overview")
-        self.assertEqual(settings.default_tabs[0].url, "/todos/{{pk}}/")
-        self.assertIsInstance(settings.default_tabs[1], DetailTabFolder)
-        self.assertEqual(settings.default_tabs[1].tabs[0].name, "Initiative")
+        primary = settings.tab_configurations[0]
+        self.assertEqual(primary.name, "Primary")
+        self.assertEqual(primary.tabs[0].name, "Overview")
+        self.assertEqual(primary.tabs[0].url_name, "todos_detail_overview")
+        self.assertIsInstance(primary.tabs[1], DetailTabFolder)
+        self.assertEqual(primary.tabs[1].tabs[0].name, "Initiative")
 
-        # 3. Confirm absent and explicitly empty overrides remain distinguishable.
-        self.assertIsNone(DetailViewSettings().default_tabs)
-        self.assertEqual(DetailViewSettings(default_tabs=[]).default_tabs, [])
+        # 3. Confirm the API accepts several configurations and an empty default.
+        self.assertEqual(settings.tab_configurations[1].name, "Empty")
+        self.assertEqual(DetailViewSettings().tab_configurations, [])
 
-    def test_detail_view_settings_reject_invalid_default_tabs(self):
+    def test_detail_view_settings_reject_invalid_tab_configurations(self):
         """
         Use case: A model declares malformed default tabs or nested folders.
         Expected result: Configuration validation fails during application startup.
@@ -111,23 +123,35 @@ class DetailViewSettingsTests(SimpleTestCase):
         # 1. Reject unsupported URL templates.
         with self.assertRaisesRegex(ValidationError, "Only the.*pk.*placeholder"):
             DetailViewSettings(
-                default_tabs=[
-                    DetailTab(name="Invalid", url="/todos/{{user_id}}/")
+                tab_configurations=[
+                    DetailTabsConfiguration(
+                        tabs=[DetailTab(name="Invalid", url="/todos/{{user_id}}/")]
+                    )
                 ]
             )
 
-        # 2. Reject folders inside folders through the concrete child type.
+        # 2. Require exactly one literal URL or URL name for each tab.
+        with self.assertRaisesRegex(ValidationError, "exactly one of url or url_name"):
+            DetailTab(name="Missing target")
+        with self.assertRaisesRegex(ValidationError, "exactly one of url or url_name"):
+            DetailTab(name="Ambiguous", url="/todos/{{pk}}/", url_name="todos")
+
+        # 3. Reject folders inside folders through the concrete child type.
         with self.assertRaises(ValidationError):
             DetailViewSettings(
-                default_tabs=[
-                    {
-                        "name": "Parent",
-                        "tabs": [
+                tab_configurations=[
+                    DetailTabsConfiguration(
+                        tabs=[
                             {
-                                "name": "Nested",
-                                "tabs": [],
+                                "name": "Parent",
+                                "tabs": [
+                                    {
+                                        "name": "Nested",
+                                        "tabs": [],
+                                    }
+                                ],
                             }
-                        ],
-                    }
+                        ]
+                    )
                 ]
             )

--- a/bloomerp/django_bloomerp/bloomerp/tests/models/test_user_detail_view_tabs_preference.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/models/test_user_detail_view_tabs_preference.py
@@ -8,7 +8,12 @@ from django.test import TestCase
 from django.urls import reverse
 
 from bloomerp.models import Todo, User
-from bloomerp.models.definition import DetailTab, DetailTabFolder, DetailViewSettings
+from bloomerp.models.definition import (
+    DetailTab,
+    DetailTabFolder,
+    DetailTabsConfiguration,
+    DetailViewSettings,
+)
 from bloomerp.models.users.user_detail_view_tabs_preference import (
     UserDetailViewTabItem,
     UserDetailViewTabsPreference,
@@ -33,11 +38,16 @@ class UserDetailViewTabsPreferenceTests(TestCase):
         Use case: A user opens a model detail page without a tabs preference.
         Expected result: The default preference contains every one-PK detail route using {{pk}} URLs.
         """
-        # 1. Create the default preference through the required BasePreference factory.
-        preference = UserDetailViewTabsPreference.create_default_for_user(
-            self.owner,
-            content_type_id=self.content_type.pk,
-        )
+        # 1. Create the router-derived preference through the required factory.
+        with patch.object(
+            Todo.bloomerp_config,
+            "detail_view_settings",
+            DetailViewSettings(),
+        ):
+            preference = UserDetailViewTabsPreference.create_default_for_user(
+                self.owner,
+                content_type_id=self.content_type.pk,
+            )
 
         # 2. Compare the relational tab items with the route catalog.
         options = UserDetailViewTabsPreference.get_detail_route_options(Todo)
@@ -60,29 +70,42 @@ class UserDetailViewTabsPreferenceTests(TestCase):
                 [option["url"] for option in relationship_options],
             )
 
-    def test_model_config_default_tabs_override_router_generated_tabs(self):
+    def test_model_config_creates_all_named_tab_configurations(self):
         """
-        Use case: A model declares a custom default detail-tab layout.
-        Expected result: The preference materializes only that ordered tab and folder tree.
+        Use case: A model declares multiple named detail-tab configurations.
+        Expected result: Every named preference is materialized and the first is selected.
         """
-        # 1. Configure a custom top-level layout for the Todo model.
+        # 1. Configure two layouts, including a tab identified by route name.
         detail_view_settings = DetailViewSettings(
-            default_tabs=[
-                DetailTab(name="Summary", url="/todos/{{pk}}/summary/"),
-                DetailTabFolder(
-                    name="Related work",
+            tab_configurations=[
+                DetailTabsConfiguration(
+                    name="Daily work",
                     tabs=[
-                        DetailTab(
-                            name="Initiative",
-                            url="/todos/{{pk}}/initiative/",
-                        ),
-                        DetailTab(
-                            name="Dependencies",
-                            url="/todos/{{pk}}/dependencies/",
+                        DetailTab(name="Summary", url_name="todos_detail_overview"),
+                        DetailTabFolder(
+                            name="Related work",
+                            tabs=[
+                                DetailTab(
+                                    name="Initiative",
+                                    url="/todos/{{pk}}/initiative/",
+                                ),
+                                DetailTab(
+                                    name="Dependencies",
+                                    url="/todos/{{pk}}/dependencies/",
+                                ),
+                            ],
                         ),
                     ],
                 ),
-                DetailTab(name="Documentation", url="https://docs.example.com/"),
+                DetailTabsConfiguration(
+                    name="Reference",
+                    tabs=[
+                        DetailTab(
+                            name="Documentation",
+                            url="https://docs.example.com/",
+                        )
+                    ],
+                ),
             ]
         )
 
@@ -97,16 +120,31 @@ class UserDetailViewTabsPreferenceTests(TestCase):
                 content_type_id=self.content_type.pk,
             )
 
-        # 3. Confirm exact top-level order and folder membership were materialized.
+        # 3. Confirm both names, selection, route resolution, and trees were materialized.
+        preferences = list(
+            UserDetailViewTabsPreference.objects.filter(
+                user=self.owner,
+                content_type=self.content_type,
+            ).order_by("pk")
+        )
+        self.assertEqual(
+            [(item.name, item.selected) for item in preferences],
+            [("Daily work", True), ("Reference", False)],
+        )
+        self.assertEqual(preference, preferences[0])
+
         top_level = list(
             preference.items.filter(parent=None).order_by("position", "id")
+        )
+        overview_url = UserDetailViewTabsPreference.get_configured_tab_url(
+            DetailTab(name="Summary", url_name="todos_detail_overview"),
+            Todo,
         )
         self.assertEqual(
             [(item.name, item.url, item.position) for item in top_level],
             [
-                ("Summary", "/todos/{{pk}}/summary/", 0),
+                ("Summary", overview_url, 0),
                 ("Related work", None, 1),
-                ("Documentation", "https://docs.example.com/", 2),
             ],
         )
         self.assertEqual(
@@ -122,9 +160,13 @@ class UserDetailViewTabsPreferenceTests(TestCase):
                 ("Dependencies", "/todos/{{pk}}/dependencies/", 1),
             ],
         )
-        self.assertEqual(preference.items.count(), 5)
+        self.assertEqual(preference.items.count(), 4)
+        self.assertEqual(
+            list(preferences[1].items.values_list("name", "url")),
+            [("Documentation", "https://docs.example.com/")],
+        )
 
-    def test_explicit_empty_model_config_default_tabs_create_no_items(self):
+    def test_empty_named_tab_configuration_creates_no_items(self):
         """
         Use case: A model explicitly declares an empty default tab layout.
         Expected result: Router-derived tabs are suppressed and no items are created.
@@ -133,7 +175,11 @@ class UserDetailViewTabsPreferenceTests(TestCase):
         with patch.object(
             Todo.bloomerp_config,
             "detail_view_settings",
-            DetailViewSettings(default_tabs=[]),
+            DetailViewSettings(
+                tab_configurations=[
+                    DetailTabsConfiguration(name="Minimal", tabs=[])
+                ]
+            ),
         ):
             preference = UserDetailViewTabsPreference.create_default_for_user(
                 self.owner,
@@ -141,6 +187,7 @@ class UserDetailViewTabsPreferenceTests(TestCase):
             )
 
         # 2. Confirm the empty override did not fall back to router defaults.
+        self.assertEqual(preference.name, "Minimal")
         self.assertFalse(preference.items.exists())
 
     def test_preference_api_is_owner_scoped_and_items_are_not_exposed(self):

--- a/bloomerp/django_bloomerp/bloomerp/tests/models/test_user_detail_view_tabs_preference.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/models/test_user_detail_view_tabs_preference.py
@@ -1,5 +1,6 @@
 import json
 import uuid
+from unittest.mock import patch
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
@@ -7,6 +8,7 @@ from django.test import TestCase
 from django.urls import reverse
 
 from bloomerp.models import Todo, User
+from bloomerp.models.definition import DetailTab, DetailTabFolder, DetailViewSettings
 from bloomerp.models.users.user_detail_view_tabs_preference import (
     UserDetailViewTabItem,
     UserDetailViewTabsPreference,
@@ -57,6 +59,89 @@ class UserDetailViewTabsPreferenceTests(TestCase):
                 list(folder.children.values_list("url", flat=True)),
                 [option["url"] for option in relationship_options],
             )
+
+    def test_model_config_default_tabs_override_router_generated_tabs(self):
+        """
+        Use case: A model declares a custom default detail-tab layout.
+        Expected result: The preference materializes only that ordered tab and folder tree.
+        """
+        # 1. Configure a custom top-level layout for the Todo model.
+        detail_view_settings = DetailViewSettings(
+            default_tabs=[
+                DetailTab(name="Summary", url="/todos/{{pk}}/summary/"),
+                DetailTabFolder(
+                    name="Related work",
+                    tabs=[
+                        DetailTab(
+                            name="Initiative",
+                            url="/todos/{{pk}}/initiative/",
+                        ),
+                        DetailTab(
+                            name="Dependencies",
+                            url="/todos/{{pk}}/dependencies/",
+                        ),
+                    ],
+                ),
+                DetailTab(name="Documentation", url="https://docs.example.com/"),
+            ]
+        )
+
+        # 2. Create the default preference while that model configuration is active.
+        with patch.object(
+            Todo.bloomerp_config,
+            "detail_view_settings",
+            detail_view_settings,
+        ):
+            preference = UserDetailViewTabsPreference.create_default_for_user(
+                self.owner,
+                content_type_id=self.content_type.pk,
+            )
+
+        # 3. Confirm exact top-level order and folder membership were materialized.
+        top_level = list(
+            preference.items.filter(parent=None).order_by("position", "id")
+        )
+        self.assertEqual(
+            [(item.name, item.url, item.position) for item in top_level],
+            [
+                ("Summary", "/todos/{{pk}}/summary/", 0),
+                ("Related work", None, 1),
+                ("Documentation", "https://docs.example.com/", 2),
+            ],
+        )
+        self.assertEqual(
+            list(
+                top_level[1].children.order_by("position", "id").values_list(
+                    "name",
+                    "url",
+                    "position",
+                )
+            ),
+            [
+                ("Initiative", "/todos/{{pk}}/initiative/", 0),
+                ("Dependencies", "/todos/{{pk}}/dependencies/", 1),
+            ],
+        )
+        self.assertEqual(preference.items.count(), 5)
+
+    def test_explicit_empty_model_config_default_tabs_create_no_items(self):
+        """
+        Use case: A model explicitly declares an empty default tab layout.
+        Expected result: Router-derived tabs are suppressed and no items are created.
+        """
+        # 1. Configure an explicit empty override and create the preference.
+        with patch.object(
+            Todo.bloomerp_config,
+            "detail_view_settings",
+            DetailViewSettings(default_tabs=[]),
+        ):
+            preference = UserDetailViewTabsPreference.create_default_for_user(
+                self.owner,
+                content_type_id=self.content_type.pk,
+            )
+
+        # 2. Confirm the empty override did not fall back to router defaults.
+        self.assertFalse(preference.items.exists())
 
     def test_preference_api_is_owner_scoped_and_items_are_not_exposed(self):
         """


### PR DESCRIPTION
## To-do

- ID: `3697faca-e0f0-43a8-aa0d-8d04e8774b91`
- Title: Add ability to add default tabs on models

## Summary

- add declarative `DetailTab` and `DetailTabFolder` Pydantic models
- expose model defaults through `DetailViewSettings.default_tabs`
- materialize configured tabs and folders through `UserDetailViewTabsPreference.create_default_for_user`
- retain router-derived defaults when `default_tabs` is `None`
- treat an explicit empty list as an intentional empty override
- share URL-template validation between declarative defaults and user-created tabs

## Verification

Passed:

- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.models.test_model_definition bloomerp.tests.models.test_user_detail_view_tabs_preference`
  - 18 tests passed
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py check`
  - system check identified no issues
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py makemigrations --check --dry-run`
  - no changes detected
- `git diff --check`

Broader run:

- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run python manage.py test bloomerp.tests.models bloomerp.tests.services.test_preference_services`
  - 64 tests passed; 1 unrelated existing import error in `test_application_field` for missing `save_submitted_one_to_many_fields`, and 1 unrelated existing inbox rendering assertion failure
