### PR TITLE
[BUG] Dark mode misses some elements

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/src/styles.css
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/src/styles.css
@@ -111,6 +111,8 @@
 
   html.dark {
     color-scheme: dark;
+    --color-base: var(--color-zinc-800);
+    --color-light: var(--color-zinc-300);
   }
 }
 
@@ -120,7 +122,7 @@
 * without spreading theme state or one-off selectors throughout the app.
 */
 @layer utilities {
-  .dark .bg-white { background-color: var(--color-zinc-900); }
+  .dark .bg-white { background-color: var(--color-zinc-800); }
   .dark .bg-gray-50 { background-color: var(--color-zinc-900); }
   .dark .bg-gray-100 { background-color: var(--color-zinc-800); }
   .dark .bg-gray-200 { background-color: var(--color-zinc-700); }
@@ -269,8 +271,16 @@
         @apply bg-primary text-white border-[var(--color-primary-600)] ring-[var(--color-primary-500)];
     }
 
+    .dark .btn-primary:not(.btn-outline) {
+        @apply bg-zinc-800 border-zinc-600 text-zinc-100;
+    }
+
     .btn-primary:hover:not(:disabled) {
         @apply bg-[var(--color-primary-700)] border-[var(--color-primary-700)] text-white;
+    }
+
+    .dark .btn-primary:not(.btn-outline):hover:not(:disabled) {
+        @apply bg-zinc-700 border-zinc-500 text-zinc-100;
     }
 
     /* Reset primary button hover text color to override generic link hover */


### PR DESCRIPTION
## Todo
- ID: `cc3142b0-683c-4233-94df-bfc500050254`
- Title: [BUG] Dark mode misses some elements

## Summary
- Add dark-mode values for the shared `base` and `light` theme tokens.
- Map legacy `bg-white` surfaces to `zinc-800` in the shared stylesheet.
- Style primary buttons through the shared component stylesheet.
- Keep templates unchanged and preserve the existing `text-primary-900` dark mapping.

## Verification
- `npm run build` (from `bloomerp/django_bloomerp/bloomerp/static_src`) — passed; Tailwind, TypeScript, and Vite completed successfully.
- Tests not run, as explicitly requested by the user; UI acceptance testing remains appropriate for this visual change.

## Notes
- The pre-existing `bloomerp/django_bloomerp/uv.lock` modification is not included.