### PR TITLE
Fix comments component template path

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/components/objects/comments.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/objects/comments.py
@@ -42,7 +42,7 @@ def comments(request:HttpRequest, content_type_id:int, object_id:str) -> HttpRes
     
     return render(
         request,
-        "components/comments.html",
+        "components/objects/comments.html",
         context={
             "object" : object,
             "content_type_id" : content_type_id,


### PR DESCRIPTION
## Todo
`todo/2413-bug-comments-not-working-anymore`

## Summary
- Correct the comments component view to render the template at its actual `components/objects/comments.html` path.

## Testing
- Not run; the ticket specifies that testing is not required.