### PR TITLE
[CLI] Add bloomerp upgrade command

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/cli/main.py
+++ b/bloomerp/django_bloomerp/bloomerp/cli/main.py
@@ -8,6 +8,7 @@ from .marketplace import marketplace
 from .organization import organization
 from .project import project
 from .sync import sync
+from .upgrade import upgrade
 
 @click.group()
 def main() -> None:
@@ -20,6 +21,7 @@ main.add_command(project)
 main.add_command(app)
 main.add_command(marketplace)
 main.add_command(sync)
+main.add_command(upgrade)
 
 if __name__ == "__main__":
     main()

--- a/bloomerp/django_bloomerp/bloomerp/cli/upgrade.py
+++ b/bloomerp/django_bloomerp/bloomerp/cli/upgrade.py
@@ -85,8 +85,8 @@ def _bloomerp_requirement(dependencies: object) -> tuple[str, str]:
     return dependency, f"Bloomerp{extras}=={{version}}{marker}"
 
 
-def updated_pyproject_contents(path: Path, version: str) -> str:
-    """Return pyproject contents with its Bloomerp requirement pinned to VERSION."""
+def updated_pyproject_contents(path: Path, version: str) -> tuple[str, str]:
+    """Return updated pyproject contents and the exact Bloomerp requirement."""
 
     try:
         contents = path.read_text(encoding="utf-8")
@@ -120,11 +120,12 @@ def updated_pyproject_contents(path: Path, version: str) -> str:
             "Use a standard double-quoted dependency entry."
         )
     updated_section = section.replace(encoded_current, encoded_replacement, 1)
-    return (
+    updated_contents = (
         contents[: project_match.start()]
         + updated_section
         + contents[project_match.end() :]
     )
+    return updated_contents, replacement
 
 
 def _environment_python(project_root: Path, explicit_python: Path | None) -> Path:
@@ -133,11 +134,16 @@ def _environment_python(project_root: Path, explicit_python: Path | None) -> Pat
 
     active_environment = os.environ.get("VIRTUAL_ENV")
     if active_environment:
-        candidate = Path(active_environment) / "bin" / "python"
-        if candidate.is_file():
-            return candidate.resolve()
+        environment_root = Path(active_environment)
+        candidates = (
+            environment_root / "bin" / "python",
+            environment_root / "Scripts" / "python.exe",
+        )
+        for candidate in candidates:
+            if candidate.is_file():
+                return candidate.resolve()
         raise click.ClickException(
-            f"VIRTUAL_ENV does not contain a Python executable: {candidate}"
+            f"VIRTUAL_ENV does not contain a Python executable: {environment_root}"
         )
 
     candidates = (
@@ -155,13 +161,13 @@ def _environment_python(project_root: Path, explicit_python: Path | None) -> Pat
 
 
 def install_bloomerp(
-    version: str,
+    requirement: str,
     *,
     project_root: Path,
     explicit_python: Path | None,
     system: bool,
 ) -> Path:
-    """Install an exact Bloomerp version into the selected Python environment."""
+    """Install a Bloomerp requirement into the selected Python environment."""
 
     if explicit_python is not None and system:
         raise click.ClickException("--python and --system cannot be used together.")
@@ -172,7 +178,6 @@ def install_bloomerp(
     if not python.is_file():
         raise click.ClickException(f"Python executable does not exist: {python}")
 
-    requirement = f"Bloomerp=={version}"
     uv = shutil.which("uv")
     command = (
         [uv, "pip", "install", "--python", str(python), requirement]
@@ -223,7 +228,10 @@ def upgrade(
     metadata_dir = get_project_metadata_dir()
     project_root = metadata_dir.parent
     pyproject_path = project_root / "pyproject.toml"
-    pyproject_contents = updated_pyproject_contents(pyproject_path, selected_version)
+    pyproject_contents, requirement = updated_pyproject_contents(
+        pyproject_path,
+        selected_version,
+    )
     manifest = get_project_manifest()
     manifest = manifest.model_copy(
         update={
@@ -236,7 +244,7 @@ def upgrade(
     installed_python = None
     if install:
         installed_python = install_bloomerp(
-            selected_version,
+            requirement,
             project_root=project_root,
             explicit_python=python_path,
             system=system,

--- a/bloomerp/django_bloomerp/bloomerp/cli/upgrade.py
+++ b/bloomerp/django_bloomerp/bloomerp/cli/upgrade.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tomllib
+from pathlib import Path
+
+import click
+import requests
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.version import InvalidVersion, Version
+
+from .utils import (
+    get_project_manifest,
+    get_project_metadata_dir,
+    write_project_manifest,
+)
+
+
+PYPI_PROJECT_URL = "https://pypi.org/pypi/Bloomerp/json"
+
+
+def normalize_version(value: str) -> str:
+    """Return VALUE as a normalized PEP 440 release version."""
+
+    try:
+        return str(Version(value.strip()))
+    except InvalidVersion as exc:
+        raise click.ClickException(f"Invalid Bloomerp version: {value!r}.") from exc
+
+
+def latest_bloomerp_version() -> str:
+    """Return the latest Bloomerp version published on PyPI."""
+
+    try:
+        response = requests.get(PYPI_PROJECT_URL, timeout=30)
+        response.raise_for_status()
+        payload = response.json()
+    except (requests.RequestException, ValueError) as exc:
+        raise click.ClickException(
+            f"Could not resolve the latest Bloomerp version from PyPI: {exc}"
+        ) from exc
+
+    info = payload.get("info") if isinstance(payload, dict) else None
+    version = info.get("version") if isinstance(info, dict) else None
+    if not isinstance(version, str) or not version.strip():
+        raise click.ClickException("PyPI returned invalid Bloomerp release metadata.")
+    return normalize_version(version)
+
+
+def _bloomerp_requirement(dependencies: object) -> tuple[str, str]:
+    if not isinstance(dependencies, list):
+        raise click.ClickException(
+            "pyproject.toml [project].dependencies must be a list."
+        )
+
+    matches = []
+    for dependency in dependencies:
+        if not isinstance(dependency, str):
+            continue
+        try:
+            requirement = Requirement(dependency)
+        except InvalidRequirement:
+            continue
+        if requirement.name.lower() == "bloomerp":
+            matches.append((dependency, requirement))
+
+    if not matches:
+        raise click.ClickException(
+            "pyproject.toml does not declare Bloomerp in [project].dependencies."
+        )
+    if len(matches) > 1:
+        raise click.ClickException(
+            "pyproject.toml declares Bloomerp more than once in "
+            "[project].dependencies."
+        )
+
+    dependency, requirement = matches[0]
+    extras = f"[{','.join(sorted(requirement.extras))}]" if requirement.extras else ""
+    marker = f"; {requirement.marker}" if requirement.marker else ""
+    return dependency, f"Bloomerp{extras}=={{version}}{marker}"
+
+
+def updated_pyproject_contents(path: Path, version: str) -> str:
+    """Return pyproject contents with its Bloomerp requirement pinned to VERSION."""
+
+    try:
+        contents = path.read_text(encoding="utf-8")
+        document = tomllib.loads(contents)
+    except FileNotFoundError as exc:
+        raise click.ClickException(
+            f"Missing project build configuration: {path}"
+        ) from exc
+    except tomllib.TOMLDecodeError as exc:
+        raise click.ClickException(f"Invalid pyproject.toml: {exc}") from exc
+
+    project = document.get("project")
+    if not isinstance(project, dict):
+        raise click.ClickException("pyproject.toml does not contain a [project] table.")
+    current, replacement_template = _bloomerp_requirement(project.get("dependencies"))
+    replacement = replacement_template.format(version=version)
+
+    project_match = re.search(
+        r"(?ms)^\[project\][ \t]*$.*?(?=^\[(?!project(?:\.|\]))|\Z)",
+        contents,
+    )
+    if project_match is None:
+        raise click.ClickException("Could not locate [project] in pyproject.toml.")
+
+    section = project_match.group(0)
+    encoded_current = json.dumps(current)
+    encoded_replacement = json.dumps(replacement)
+    if section.count(encoded_current) != 1:
+        raise click.ClickException(
+            "Could not safely update the Bloomerp dependency in pyproject.toml. "
+            "Use a standard double-quoted dependency entry."
+        )
+    updated_section = section.replace(encoded_current, encoded_replacement, 1)
+    return (
+        contents[: project_match.start()]
+        + updated_section
+        + contents[project_match.end() :]
+    )
+
+
+def _environment_python(project_root: Path, explicit_python: Path | None) -> Path:
+    if explicit_python is not None:
+        return explicit_python.expanduser().resolve()
+
+    active_environment = os.environ.get("VIRTUAL_ENV")
+    if active_environment:
+        candidate = Path(active_environment) / "bin" / "python"
+        if candidate.is_file():
+            return candidate.resolve()
+        raise click.ClickException(
+            f"VIRTUAL_ENV does not contain a Python executable: {candidate}"
+        )
+
+    candidates = (
+        project_root / ".venv" / "bin" / "python",
+        project_root / ".venv" / "Scripts" / "python.exe",
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve()
+
+    raise click.ClickException(
+        "No project Python environment found. Activate a virtual environment, "
+        "create .venv, pass --python, or explicitly use --system."
+    )
+
+
+def install_bloomerp(
+    version: str,
+    *,
+    project_root: Path,
+    explicit_python: Path | None,
+    system: bool,
+) -> Path:
+    """Install an exact Bloomerp version into the selected Python environment."""
+
+    if explicit_python is not None and system:
+        raise click.ClickException("--python and --system cannot be used together.")
+    python = Path(sys.executable).resolve() if system else _environment_python(
+        project_root,
+        explicit_python,
+    )
+    if not python.is_file():
+        raise click.ClickException(f"Python executable does not exist: {python}")
+
+    requirement = f"Bloomerp=={version}"
+    uv = shutil.which("uv")
+    command = (
+        [uv, "pip", "install", "--python", str(python), requirement]
+        if uv
+        else [str(python), "-m", "pip", "install", requirement]
+    )
+    try:
+        subprocess.run(command, cwd=project_root, check=True)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise click.ClickException(
+            f"Could not install {requirement} into {python}."
+        ) from exc
+    return python
+
+
+@click.command("upgrade")
+@click.argument("version", required=False)
+@click.option(
+    "--install",
+    is_flag=True,
+    help="Install the selected version into the project Python environment.",
+)
+@click.option(
+    "--python",
+    "python_path",
+    type=click.Path(path_type=Path, exists=True, dir_okay=False),
+    help="Python executable to use with --install.",
+)
+@click.option(
+    "--system",
+    is_flag=True,
+    help="With --install, explicitly install into the CLI's Python environment.",
+)
+def upgrade(
+    version: str | None,
+    install: bool,
+    python_path: Path | None,
+    system: bool,
+) -> None:
+    """Upgrade a Bloomerp project's declared runtime version."""
+
+    if (python_path is not None or system) and not install:
+        raise click.ClickException("--python and --system require --install.")
+
+    selected_version = (
+        normalize_version(version) if version else latest_bloomerp_version()
+    )
+    metadata_dir = get_project_metadata_dir()
+    project_root = metadata_dir.parent
+    pyproject_path = project_root / "pyproject.toml"
+    pyproject_contents = updated_pyproject_contents(pyproject_path, selected_version)
+    manifest = get_project_manifest()
+    manifest = manifest.model_copy(
+        update={
+            "runtime": manifest.runtime.model_copy(
+                update={"bloomerp_version": selected_version}
+            )
+        }
+    )
+
+    installed_python = None
+    if install:
+        installed_python = install_bloomerp(
+            selected_version,
+            project_root=project_root,
+            explicit_python=python_path,
+            system=system,
+        )
+
+    pyproject_path.write_text(pyproject_contents, encoding="utf-8")
+    write_project_manifest(manifest)
+    click.echo(f"Upgraded project metadata to Bloomerp {selected_version}.")
+    if installed_python is not None:
+        click.echo(f"Installed Bloomerp {selected_version} into {installed_python}.")
+    else:
+        click.echo(
+            "Run your package manager's install/sync command, or rerun with "
+            "--install to update the project environment."
+        )

--- a/bloomerp/django_bloomerp/bloomerp/tests/cli/test_cli_upgrade.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/cli/test_cli_upgrade.py
@@ -144,6 +144,88 @@ def test_upgrade_install_targets_project_virtualenv_through_uv():
         )
 
 
+def test_upgrade_install_preserves_dependency_extras_and_marker():
+    """
+    Use case: The project's Bloomerp dependency declares extras and a marker.
+    Expected result: Installation uses the complete rewritten requirement.
+    """
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        # 1. Create a project with optional Bloomerp dependencies and a target Python.
+        _manifest_path, pyproject_path = create_project()
+        pyproject_path.write_text(
+            pyproject_path.read_text(encoding="utf-8").replace(
+                "Bloomerp>=1.14",
+                'Bloomerp[postgres]>=1.14; python_version >= \\"3.12\\"',
+            ),
+            encoding="utf-8",
+        )
+        python = Path(".venv/bin/python")
+        python.parent.mkdir(parents=True)
+        python.write_text("", encoding="utf-8")
+
+        # 2. Upgrade and install the dependency through uv.
+        with (
+            patch.dict(os.environ, {"VIRTUAL_ENV": ""}),
+            patch("bloomerp.cli.upgrade.shutil.which", return_value="/usr/bin/uv"),
+            patch("bloomerp.cli.upgrade.subprocess.run") as run,
+        ):
+            result = runner.invoke(main, ["upgrade", "1.15.0", "--install"])
+
+        # 3. Verify the installer and pyproject receive the same full requirement.
+        requirement = 'Bloomerp[postgres]==1.15.0; python_version >= "3.12"'
+        assert result.exit_code == 0, result.output
+        run.assert_called_once_with(
+            [
+                "/usr/bin/uv",
+                "pip",
+                "install",
+                "--python",
+                str(python.resolve()),
+                requirement,
+            ],
+            cwd=Path.cwd(),
+            check=True,
+        )
+        dependencies = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))[
+            "project"
+        ]["dependencies"]
+        assert requirement in dependencies
+
+
+def test_upgrade_install_finds_windows_active_virtualenv():
+    """
+    Use case: An activated Windows virtualenv exposes Python under Scripts.
+    Expected result: Installation targets that Python executable.
+    """
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        # 1. Create a project and a Windows-style active virtualenv interpreter.
+        create_project()
+        environment = Path("active-environment").resolve()
+        python = environment / "Scripts" / "python.exe"
+        python.parent.mkdir(parents=True)
+        python.write_text("", encoding="utf-8")
+
+        # 2. Upgrade while VIRTUAL_ENV points to the Windows-style environment.
+        with (
+            patch.dict(os.environ, {"VIRTUAL_ENV": str(environment)}),
+            patch("bloomerp.cli.upgrade.shutil.which", return_value=None),
+            patch("bloomerp.cli.upgrade.subprocess.run") as run,
+        ):
+            result = runner.invoke(main, ["upgrade", "1.15.0", "--install"])
+
+        # 3. Verify the pip fallback targets Scripts/python.exe.
+        assert result.exit_code == 0, result.output
+        run.assert_called_once_with(
+            [str(python), "-m", "pip", "install", "Bloomerp==1.15.0"],
+            cwd=Path.cwd(),
+            check=True,
+        )
+
+
 def test_upgrade_install_refuses_implicit_global_environment_before_writes():
     """
     Use case: Installation is requested without a virtualenv or explicit override.

--- a/bloomerp/django_bloomerp/bloomerp/tests/cli/test_cli_upgrade.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/cli/test_cli_upgrade.py
@@ -1,0 +1,172 @@
+import os
+import subprocess
+import tomllib
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from click.testing import CliRunner
+
+from bloomerp.cli.base import (
+    BloomerpEnvironment,
+    BloomerpProjectManifest,
+    BloomerpRuntime,
+)
+from bloomerp.cli.main import main
+from bloomerp.cli.toml import write_toml_model
+
+
+def create_project() -> tuple[Path, Path]:
+    metadata_dir = Path(".bloomerp")
+    metadata_dir.mkdir()
+    manifest_path = metadata_dir / "project.bloomerp.toml"
+    write_toml_model(
+        manifest_path,
+        BloomerpProjectManifest(
+            name="Example",
+            description="Upgrade test",
+            environment=BloomerpEnvironment(),
+            runtime=BloomerpRuntime(
+                bloomerp_version="1.14.7",
+                python_version="3.13",
+            ),
+        ),
+    )
+    pyproject_path = Path("pyproject.toml")
+    pyproject_path.write_text(
+        '''[project]
+name = "example"
+version = "0.1.0"
+dependencies = [
+    "Django>=5.1,<6",
+    "Bloomerp>=1.14",
+]
+
+[tool.example]
+preserved = true
+''',
+        encoding="utf-8",
+    )
+    return manifest_path, pyproject_path
+
+
+def test_upgrade_explicit_version_updates_project_files_without_installing():
+    """
+    Use case: A user selects an exact Bloomerp version without --install.
+    Expected result: Both declarations update while the environment stays untouched.
+    """
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        # 1. Create project metadata with an older dependency constraint.
+        manifest_path, pyproject_path = create_project()
+
+        # 2. Upgrade to an explicitly selected release.
+        with patch("bloomerp.cli.upgrade.subprocess.run") as run:
+            result = runner.invoke(main, ["upgrade", "1.15.0"])
+
+        # 3. Verify both files and the non-installing default.
+        assert result.exit_code == 0, result.output
+        assert run.call_count == 0
+        pyproject = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+        assert pyproject["project"]["dependencies"] == [
+            "Django>=5.1,<6",
+            "Bloomerp==1.15.0",
+        ]
+        assert pyproject["tool"]["example"]["preserved"] is True
+        manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+        assert manifest["runtime"]["bloomerp_version"] == "1.15.0"
+        assert "package manager" in result.output
+
+
+def test_upgrade_without_version_uses_latest_pypi_release():
+    """
+    Use case: A user omits the target version.
+    Expected result: The latest PyPI release is normalized and selected.
+    """
+    runner = CliRunner()
+    response = Mock()
+    response.json.return_value = {"info": {"version": "1.16.0"}}
+
+    with runner.isolated_filesystem():
+        # 1. Create project metadata.
+        manifest_path, _pyproject_path = create_project()
+
+        # 2. Resolve and apply the latest published release.
+        with patch("bloomerp.cli.upgrade.requests.get", return_value=response) as get:
+            result = runner.invoke(main, ["upgrade"])
+
+        # 3. Verify PyPI lookup and the selected manifest version.
+        assert result.exit_code == 0, result.output
+        get.assert_called_once_with(
+            "https://pypi.org/pypi/Bloomerp/json",
+            timeout=30,
+        )
+        response.raise_for_status.assert_called_once_with()
+        manifest = tomllib.loads(manifest_path.read_text(encoding="utf-8"))
+        assert manifest["runtime"]["bloomerp_version"] == "1.16.0"
+
+
+def test_upgrade_install_targets_project_virtualenv_through_uv():
+    """
+    Use case: A project-local virtual environment exists and --install is requested.
+    Expected result: uv installs the exact release into that interpreter.
+    """
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        # 1. Create project metadata and its local Python environment marker.
+        create_project()
+        python = Path(".venv/bin/python")
+        python.parent.mkdir(parents=True)
+        python.write_text("", encoding="utf-8")
+
+        # 2. Upgrade and install through uv into the resolved interpreter.
+        with (
+            patch.dict(os.environ, {"VIRTUAL_ENV": ""}),
+            patch("bloomerp.cli.upgrade.shutil.which", return_value="/usr/bin/uv"),
+            patch("bloomerp.cli.upgrade.subprocess.run") as run,
+        ):
+            result = runner.invoke(main, ["upgrade", "1.15.0", "--install"])
+
+        # 3. Verify the exact interpreter and release passed to the installer.
+        assert result.exit_code == 0, result.output
+        run.assert_called_once_with(
+            [
+                "/usr/bin/uv",
+                "pip",
+                "install",
+                "--python",
+                str(python.resolve()),
+                "Bloomerp==1.15.0",
+            ],
+            cwd=Path.cwd(),
+            check=True,
+        )
+
+
+def test_upgrade_install_refuses_implicit_global_environment_before_writes():
+    """
+    Use case: Installation is requested without a virtualenv or explicit override.
+    Expected result: The command fails without changing project declarations.
+    """
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        # 1. Create a project with no local environment and record its files.
+        manifest_path, pyproject_path = create_project()
+        original_manifest = manifest_path.read_text(encoding="utf-8")
+        original_pyproject = pyproject_path.read_text(encoding="utf-8")
+
+        # 2. Request installation without authorizing a target interpreter.
+        with (
+            patch.dict(os.environ, {"VIRTUAL_ENV": ""}),
+            patch("bloomerp.cli.upgrade.subprocess.run") as run,
+        ):
+            result = runner.invoke(main, ["upgrade", "1.15.0", "--install"])
+
+        # 3. Verify the safe failure occurred before installation or file writes.
+        assert result.exit_code != 0
+        assert "No project Python environment found" in result.output
+        assert run.call_count == 0
+        assert manifest_path.read_text(encoding="utf-8") == original_manifest
+        assert pyproject_path.read_text(encoding="utf-8") == original_pyproject

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.14.7"
+version = "1.14.8"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Todo

- ID: `6bba9f29-1a0c-4800-9bd6-de4937d41fbd`
- Title: `[CLI] Add "bloomerp upgrade" command`

## Summary

- add `bloomerp upgrade [VERSION]`, resolving the latest Bloomerp PyPI release when no version is supplied
- update both the `[project].dependencies` Bloomerp pin in `pyproject.toml` and `runtime.bloomerp_version` in `project.bloomerp.toml`
- preserve the surrounding `pyproject.toml` formatting and existing dependency extras or markers
- keep environment installation opt-in with `--install`; target an active virtualenv, the project `.venv`, an explicit `--python`, or an explicitly authorized `--system` environment
- use `uv pip install --python` when uv is available and fall back to the selected interpreter's pip
- perform installation before metadata writes so an install failure leaves project declarations unchanged

## Tests

- `.venv/bin/pytest -q bloomerp/tests/cli/test_cli_upgrade.py` — 6 passed
- `.venv/bin/pytest -q bloomerp/tests/cli -k 'not test_app_link_can_create_a_private_marketplace_app'` — 53 passed, 1 deselected
- `.venv/bin/python -m py_compile bloomerp/cli/upgrade.py bloomerp/tests/cli/test_cli_upgrade.py` — passed
- `git diff --check` — passed

The full CLI suite currently has one unrelated assertion mismatch in `test_app_link_can_create_a_private_marketplace_app`: `app link` now includes the merged `tagline` field, while that test still expects the older payload.
