### PR TITLE
Preserve virtualenv path during upgrade install

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/cli/upgrade.py
+++ b/bloomerp/django_bloomerp/bloomerp/cli/upgrade.py
@@ -130,7 +130,7 @@ def updated_pyproject_contents(path: Path, version: str) -> tuple[str, str]:
 
 def _environment_python(project_root: Path, explicit_python: Path | None) -> Path:
     if explicit_python is not None:
-        return explicit_python.expanduser().resolve()
+        return explicit_python.expanduser().absolute()
 
     active_environment = os.environ.get("VIRTUAL_ENV")
     if active_environment:
@@ -141,7 +141,7 @@ def _environment_python(project_root: Path, explicit_python: Path | None) -> Pat
         )
         for candidate in candidates:
             if candidate.is_file():
-                return candidate.resolve()
+                return candidate.absolute()
         raise click.ClickException(
             f"VIRTUAL_ENV does not contain a Python executable: {environment_root}"
         )
@@ -152,7 +152,7 @@ def _environment_python(project_root: Path, explicit_python: Path | None) -> Pat
     )
     for candidate in candidates:
         if candidate.is_file():
-            return candidate.resolve()
+            return candidate.absolute()
 
     raise click.ClickException(
         "No project Python environment found. Activate a virtual environment, "
@@ -171,7 +171,7 @@ def install_bloomerp(
 
     if explicit_python is not None and system:
         raise click.ClickException("--python and --system cannot be used together.")
-    python = Path(sys.executable).resolve() if system else _environment_python(
+    python = Path(sys.executable).absolute() if system else _environment_python(
         project_root,
         explicit_python,
     )

--- a/bloomerp/django_bloomerp/bloomerp/tests/cli/test_cli_upgrade.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/cli/test_cli_upgrade.py
@@ -144,6 +144,47 @@ def test_upgrade_install_targets_project_virtualenv_through_uv():
         )
 
 
+def test_upgrade_install_preserves_virtualenv_python_symlink():
+    """
+    Use case: A uv virtualenv's Python points to uv's managed base interpreter.
+    Expected result: Installation targets the virtualenv path, not the symlink target.
+    """
+    runner = CliRunner()
+
+    with runner.isolated_filesystem():
+        # 1. Create a project virtualenv linked to a managed Python installation.
+        create_project()
+        managed_python = Path("uv-managed/bin/python3.13").absolute()
+        managed_python.parent.mkdir(parents=True)
+        managed_python.write_text("", encoding="utf-8")
+        virtualenv_python = Path(".venv/bin/python")
+        virtualenv_python.parent.mkdir(parents=True)
+        virtualenv_python.symlink_to(managed_python)
+
+        # 2. Upgrade and install through uv using the project environment.
+        with (
+            patch.dict(os.environ, {"VIRTUAL_ENV": ""}),
+            patch("bloomerp.cli.upgrade.shutil.which", return_value="/usr/bin/uv"),
+            patch("bloomerp.cli.upgrade.subprocess.run") as run,
+        ):
+            result = runner.invoke(main, ["upgrade", "1.15.0", "--install"])
+
+        # 3. Verify the virtualenv path was preserved instead of dereferenced.
+        assert result.exit_code == 0, result.output
+        run.assert_called_once_with(
+            [
+                "/usr/bin/uv",
+                "pip",
+                "install",
+                "--python",
+                str(virtualenv_python.absolute()),
+                "Bloomerp==1.15.0",
+            ],
+            cwd=Path.cwd(),
+            check=True,
+        )
+
+
 def test_upgrade_install_preserves_dependency_extras_and_marker():
     """
     Use case: The project's Bloomerp dependency declares extras and a marker.

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.14.8"
+version = "1.14.9"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Follow-up to Todo

- ID: `6bba9f29-1a0c-4800-9bd6-de4937d41fbd`
- Title: `[CLI] Add "bloomerp upgrade" command`
- Follow-up to #140

## Problem

`bloomerp upgrade --install` resolved `.venv/bin/python` symlinks before passing the interpreter to uv. For uv-created environments, that dereferenced the virtualenv interpreter to uv's externally managed base Python, which uv correctly refuses to modify.

## Fix

- convert interpreter paths to absolute paths without dereferencing symlinks
- preserve virtualenv identity for project, active, explicitly supplied, and CLI-environment Python paths
- add a regression test that models `.venv/bin/python` pointing to a uv-managed interpreter and verifies uv receives the `.venv` path

## Tests

- `.venv/bin/pytest -q bloomerp/tests/cli/test_cli_upgrade.py` — 7 passed
- `.venv/bin/pytest -q bloomerp/tests/cli -k 'not test_app_link_can_create_a_private_marketplace_app'` — 54 passed, 1 deselected
- `.venv/bin/python -m py_compile bloomerp/cli/upgrade.py bloomerp/tests/cli/test_cli_upgrade.py` — passed
- `git diff --check` — passed

The excluded CLI test is an unrelated stale payload assertion: `app link` includes the merged `tagline` field while the test expects the older payload.
