### PR TITLE
Preserve workspace tile state during table pagination

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/workspaces/tiles/table.html
+++ b/bloomerp/django_bloomerp/bloomerp/templates/cotton/features/workspaces/tiles/table.html
@@ -27,14 +27,18 @@
                 Showing 0 of 0 results
             {% endif %}
         </p>
-        <nav aria-label="Pagination" class="flex items-center gap-2">
+        <nav
+            aria-label="Pagination"
+            class="flex items-center gap-2"
+            hx-target="closest [data-layout-item-body]"
+            hx-select="[data-layout-item-body]"
+            hx-swap="outerHTML"
+        >
             <div class="join">
                 <button
                     class="btn btn-sm join-item"
                     {% if not has_previous %}disabled{% endif %}
                     hx-get="{{ url }}{% if pagination_querystring %}?{{ pagination_querystring }}&page=1{% else %}?page=1{% endif %}"
-                    hx-target="#layout-field-{{ tile_id }}"
-                    hx-swap="outerHTML"
                 >
                     First
                 </button>
@@ -42,8 +46,6 @@
                     class="btn btn-sm join-item"
                     {% if not has_previous %}disabled{% endif %}
                     {% if has_previous %}hx-get="{{ url }}{% if pagination_querystring %}?{{ pagination_querystring }}&page={{ previous_page_number }}{% else %}?page={{ previous_page_number }}{% endif %}"{% endif %}
-                    hx-target="#layout-field-{{ tile_id }}"
-                    hx-swap="outerHTML"
                 >
                     Prev
                 </button>
@@ -57,8 +59,6 @@
                             <button
                                 class="btn btn-sm join-item"
                                 hx-get="{{ url }}{% if pagination_querystring %}?{{ pagination_querystring }}&page={{ page_number }}{% else %}?page={{ page_number }}{% endif %}"
-                                hx-target="#layout-field-{{ tile_id }}"
-                                hx-swap="outerHTML"
                             >
                                 {{ page_number }}
                             </button>
@@ -71,8 +71,6 @@
                     class="btn btn-sm join-item"
                     {% if not has_next %}disabled{% endif %}
                     {% if has_next %}hx-get="{{ url }}{% if pagination_querystring %}?{{ pagination_querystring }}&page={{ next_page_number }}{% else %}?page={{ next_page_number }}{% endif %}"{% endif %}
-                    hx-target="#layout-field-{{ tile_id }}"
-                    hx-swap="outerHTML"
                 >
                     Next
                 </button>
@@ -80,8 +78,6 @@
                     class="btn btn-sm join-item"
                     {% if not has_next %}disabled{% endif %}
                     hx-get="{{ url }}{% if pagination_querystring %}?{{ pagination_querystring }}&page={{ total_pages }}{% else %}?page={{ total_pages }}{% endif %}"
-                    hx-target="#layout-field-{{ tile_id }}"
-                    hx-swap="outerHTML"
                 >
                     Last
                 </button>

--- a/bloomerp/django_bloomerp/bloomerp/tests/workspaces/test_tile_rendering.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/workspaces/test_tile_rendering.py
@@ -180,6 +180,36 @@ class WorkspaceTileRenderingTests(BaseBloomerpTestCaseWithModels):
         self.assertTrue(item.border)
         self.assertNotIn("hx-get", item.content)
 
+    def test_table_pagination_replaces_only_the_layout_item_body(self):
+        html = render_to_string(
+            "cotton/features/workspaces/tiles/table.html",
+            {
+                "payload": {"columns": ["Title"], "rows": [["First row"]]},
+                "tile_id": "tile-1",
+                "url": "/components/layout/render-layout-item/1/",
+                "current_page": 1,
+                "total_pages": 2,
+                "has_previous": False,
+                "has_next": True,
+                "previous_page_number": 0,
+                "next_page_number": 2,
+                "pagination_pages": [1, 2],
+                "show_global_pagination": True,
+                "result_start": 1,
+                "result_end": 10,
+                "result_count": 11,
+                "pagination_querystring": "tile_id=tile-1&colspan=1&max_cols=4",
+            },
+        )
+        soup = BeautifulSoup(html, "html.parser")
+
+        pagination = soup.find("nav", attrs={"aria-label": "Pagination"})
+        self.assertIsNotNone(pagination)
+        self.assertEqual(pagination["hx-target"], "closest [data-layout-item-body]")
+        self.assertEqual(pagination["hx-select"], "[data-layout-item-body]")
+        self.assertEqual(pagination["hx-swap"], "outerHTML")
+        self.assertNotIn(f'#layout-field-tile-1', html)
+
     def test_data_view_tile_is_registered_with_its_builder_and_renderer(self):
         """
         Use case: A user opens the workspace tile type selector.

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.15.12"
+version = "1.15.13"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/bloomerp/django_bloomerp/uv.lock
+++ b/bloomerp/django_bloomerp/uv.lock
@@ -232,7 +232,7 @@ wheels = [
 
 [[package]]
 name = "bloomerp"
-version = "1.15.12"
+version = "1.15.13"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
## Summary
- swap only the layout item body during analytics table pagination
- preserve the tile wrapper, grid span, and registered component instance
- add regression coverage for the HTMX target and response selection
- bump the package version to 1.15.13

## Verification
- targeted workspace tile rendering tests: 3 passed
- Django system check: passed with existing third-party model warnings
- uv lock check: passed

Addresses the two unresolved review comments from #150.