### PR TITLE
[BUG] Fix approve workflow transaction handling

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/services/workflow_services.py
+++ b/bloomerp/django_bloomerp/bloomerp/services/workflow_services.py
@@ -509,7 +509,13 @@ def _execute_workflow_state(
             state.scope_key = parent_scope
         
         try:
-            output_data = node.execute(input_data)
+            if transaction.get_connection().in_atomic_block:
+                # Some executors convert database errors into workflow output.
+                # Isolate them so the surrounding workflow transaction remains usable.
+                with transaction.atomic():
+                    output_data = node.execute(input_data)
+            else:
+                output_data = node.execute(input_data)
         except Exception as error:
             _trace_node(execution_trace, node, "error", error=error)
             _create_run_step(
@@ -684,7 +690,7 @@ def resume_workflow_sync(
     paused_step: WorkflowRunStep,
     output_data=_NO_OUTPUT,
 ) -> WorkflowRun:
-    """Resume an existing workflow run after atomically claiming its paused step."""
+    """Resume an existing workflow run after a paused step."""
     with transaction.atomic():
         paused_step = WorkflowRunStep.objects.select_for_update().select_related(
             "workflow_run__workflow"
@@ -728,12 +734,9 @@ def resume_workflow_sync(
             )
             for output_node in paused_node.get_output_nodes()
         ]
-
-    # Executors may handle database errors as workflow output. Run them after
-    # the claim commits so a failed statement cannot poison the lock transaction.
-    return _execute_workflow_state(
-        workflow=workflow,
-        workflow_run=workflow_run,
-        state=state,
-        start_frames=start_frames,
-    )
+        return _execute_workflow_state(
+            workflow=workflow,
+            workflow_run=workflow_run,
+            state=state,
+            start_frames=start_frames,
+        )

--- a/bloomerp/django_bloomerp/bloomerp/services/workflow_services.py
+++ b/bloomerp/django_bloomerp/bloomerp/services/workflow_services.py
@@ -684,7 +684,7 @@ def resume_workflow_sync(
     paused_step: WorkflowRunStep,
     output_data=_NO_OUTPUT,
 ) -> WorkflowRun:
-    """Resume an existing workflow run after a paused step."""
+    """Resume an existing workflow run after atomically claiming its paused step."""
     with transaction.atomic():
         paused_step = WorkflowRunStep.objects.select_for_update().select_related(
             "workflow_run__workflow"
@@ -728,9 +728,12 @@ def resume_workflow_sync(
             )
             for output_node in paused_node.get_output_nodes()
         ]
-        return _execute_workflow_state(
-            workflow=workflow,
-            workflow_run=workflow_run,
-            state=state,
-            start_frames=start_frames,
-        )
+
+    # Executors may handle database errors as workflow output. Run them after
+    # the claim commits so a failed statement cannot poison the lock transaction.
+    return _execute_workflow_state(
+        workflow=workflow,
+        workflow_run=workflow_run,
+        state=state,
+        start_frames=start_frames,
+    )

--- a/bloomerp/django_bloomerp/bloomerp/tests/automation/test_automation.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/automation/test_automation.py
@@ -3,7 +3,7 @@ import tempfile
 from unittest.mock import patch
 
 from django.contrib.contenttypes.models import ContentType
-from django.db import models
+from django.db import models, transaction
 from django.test import TransactionTestCase
 from django_celery_beat.models import PeriodicTask
 from regex import F
@@ -17,7 +17,11 @@ from bloomerp.models import ApplicationField, User
 from bloomerp.models.automation import Workflow, WorkflowEdge, WorkflowNode
 from bloomerp.models.automation.workflow_run import WorkflowRun
 from bloomerp.models.document_templates.document_template import DocumentTemplate
-from bloomerp.celery.tasks.workflow_task import run_scheduled_workflow, run_workflow_async
+from bloomerp.celery.tasks.workflow_task import (
+    resume_workflow_async,
+    run_scheduled_workflow,
+    run_workflow_async,
+)
 from bloomerp.services.workflow_services import (
     _serialize_trigger_data,
     format_execution_trace,
@@ -284,6 +288,113 @@ class TestAutomation(TransactionTestCase):
             delay_mock.assert_called_once_with(paused_step.pk)
             paused_step.refresh_from_db()
             self.assertEqual(paused_step.status, "PAUSED")
+
+    def test_resume_workflow_executes_nodes_after_lock_transaction_commits(self):
+        """
+        Use case: A synchronous workflow continues after a paused step.
+        Expected result: Downstream nodes execute outside the transaction used to claim the step.
+        """
+        # 1. Create a workflow run with a step that can be resumed.
+        workflow = Workflow.objects.create(
+            name="Resume transaction boundary",
+            enable_logging=True,
+        )
+        trigger = WorkflowNode.objects.create(
+            workflow=workflow,
+            sub_type="HUMAN_TRIGGER",
+            parameters={"data": {"proposal": "ready"}},
+            type="TRIGGER",
+        )
+        pause_node = WorkflowNode.objects.create(
+            workflow=workflow,
+            sub_type="ENRICH_DATA",
+            parameters={"data": {}},
+            type="ACTION",
+        )
+        workflow.connect_nodes(trigger, pause_node)
+
+        with tempfile.TemporaryDirectory() as media_root, self.settings(MEDIA_ROOT=media_root):
+            workflow_run = run_workflow_sync(workflow, {})
+            paused_step = workflow_run.steps.get(sequence=1)
+            paused_step.status = "PAUSED"
+            paused_step.save(update_fields=["status"])
+
+            downstream = WorkflowNode.objects.create(
+                workflow=workflow,
+                sub_type="ENRICH_DATA",
+                parameters={"data": {"approved": True}},
+                type="ACTION",
+            )
+            workflow.connect_nodes(pause_node, downstream)
+
+            # 2. Record whether the downstream executor runs inside an atomic block.
+            atomic_states = []
+            original_execute = WorkflowNode.execute
+
+            def capture_transaction_state(node, input_data):
+                atomic_states.append(transaction.get_connection().in_atomic_block)
+                return original_execute(node, input_data)
+
+            with patch.object(WorkflowNode, "execute", new=capture_transaction_state):
+                resumed_run = resume_workflow(paused_step)
+
+            # 3. Verify execution happens after the claim transaction commits.
+            self.assertEqual(atomic_states, [False])
+            self.assertTrue(resumed_run.execution_trace[-1]["output"]["approved"])
+
+    def test_async_resume_executes_nodes_after_lock_transaction_commits(self):
+        """
+        Use case: Celery resumes an asynchronous workflow after a paused step.
+        Expected result: Downstream nodes execute outside the transaction used to claim the step.
+        """
+        # 1. Create an asynchronous workflow run with a step that can be resumed.
+        workflow = Workflow.objects.create(
+            name="Async resume transaction boundary",
+            enable_logging=True,
+            run_asynchronously=True,
+        )
+        trigger = WorkflowNode.objects.create(
+            workflow=workflow,
+            sub_type="HUMAN_TRIGGER",
+            parameters={"data": {"proposal": "ready"}},
+            type="TRIGGER",
+        )
+        pause_node = WorkflowNode.objects.create(
+            workflow=workflow,
+            sub_type="ENRICH_DATA",
+            parameters={"data": {}},
+            type="ACTION",
+        )
+        workflow.connect_nodes(trigger, pause_node)
+
+        with tempfile.TemporaryDirectory() as media_root, self.settings(MEDIA_ROOT=media_root):
+            workflow_run = run_workflow_sync(workflow, {})
+            paused_step = workflow_run.steps.get(sequence=1)
+            paused_step.status = "PAUSED"
+            paused_step.save(update_fields=["status"])
+
+            downstream = WorkflowNode.objects.create(
+                workflow=workflow,
+                sub_type="ENRICH_DATA",
+                parameters={"data": {"approved": True}},
+                type="ACTION",
+            )
+            workflow.connect_nodes(pause_node, downstream)
+
+            # 2. Run the Celery task directly and record the executor transaction state.
+            atomic_states = []
+            original_execute = WorkflowNode.execute
+
+            def capture_transaction_state(node, input_data):
+                atomic_states.append(transaction.get_connection().in_atomic_block)
+                return original_execute(node, input_data)
+
+            with patch.object(WorkflowNode, "execute", new=capture_transaction_state):
+                result = resume_workflow_async.run(paused_step.pk)
+
+            # 3. Verify the task completed after executing outside the claim transaction.
+            self.assertEqual(atomic_states, [False])
+            self.assertEqual(result["workflow_run_id"], str(workflow_run.id))
 
     def test_run_workflow_can_start_from_a_selected_node(self):
         workflow = Workflow.objects.create(name="Debug start workflow")

--- a/bloomerp/django_bloomerp/bloomerp/tests/automation/test_automation.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/automation/test_automation.py
@@ -3,7 +3,7 @@ import tempfile
 from unittest.mock import patch
 
 from django.contrib.contenttypes.models import ContentType
-from django.db import models, transaction
+from django.db import IntegrityError, models
 from django.test import TransactionTestCase
 from django_celery_beat.models import PeriodicTask
 from regex import F
@@ -16,6 +16,7 @@ from bloomerp.automation.workflow_state import WorkflowRunState
 from bloomerp.models import ApplicationField, User
 from bloomerp.models.automation import Workflow, WorkflowEdge, WorkflowNode
 from bloomerp.models.automation.workflow_run import WorkflowRun
+from bloomerp.models.automation.workflow_run_step import WorkflowRunStep
 from bloomerp.models.document_templates.document_template import DocumentTemplate
 from bloomerp.celery.tasks.workflow_task import (
     resume_workflow_async,
@@ -289,15 +290,16 @@ class TestAutomation(TransactionTestCase):
             paused_step.refresh_from_db()
             self.assertEqual(paused_step.status, "PAUSED")
 
-    def test_resume_workflow_executes_nodes_after_lock_transaction_commits(self):
-        """
-        Use case: A synchronous workflow continues after a paused step.
-        Expected result: Downstream nodes execute outside the transaction used to claim the step.
-        """
-        # 1. Create a workflow run with a step that can be resumed.
+    def _create_resumable_workflow(
+        self,
+        *,
+        run_asynchronously: bool = False,
+    ) -> tuple[WorkflowRun, WorkflowRunStep]:
+        """Create a workflow run with one paused step and one downstream node."""
         workflow = Workflow.objects.create(
             name="Resume transaction boundary",
             enable_logging=True,
+            run_asynchronously=run_asynchronously,
         )
         trigger = WorkflowNode.objects.create(
             workflow=workflow,
@@ -313,88 +315,107 @@ class TestAutomation(TransactionTestCase):
         )
         workflow.connect_nodes(trigger, pause_node)
 
+        workflow_run = run_workflow_sync(workflow, {})
+        paused_step = workflow_run.steps.get(sequence=1)
+        paused_step.status = "PAUSED"
+        paused_step.save(update_fields=["status"])
+
+        downstream = WorkflowNode.objects.create(
+            workflow=workflow,
+            sub_type="ENRICH_DATA",
+            parameters={"data": {"approved": True}},
+            type="ACTION",
+        )
+        workflow.connect_nodes(pause_node, downstream)
+        return workflow_run, paused_step
+
+    def test_resume_workflow_recovers_from_handled_database_error(self):
+        """
+        Use case: A resumed node handles a database error as workflow output.
+        Expected result: The workflow records that output without breaking its resume transaction.
+        """
+        # 1. Create a workflow run with a step that can be resumed.
         with tempfile.TemporaryDirectory() as media_root, self.settings(MEDIA_ROOT=media_root):
-            workflow_run = run_workflow_sync(workflow, {})
-            paused_step = workflow_run.steps.get(sequence=1)
-            paused_step.status = "PAUSED"
-            paused_step.save(update_fields=["status"])
+            _workflow_run, paused_step = self._create_resumable_workflow()
 
-            downstream = WorkflowNode.objects.create(
-                workflow=workflow,
-                sub_type="ENRICH_DATA",
-                parameters={"data": {"approved": True}},
-                type="ACTION",
-            )
-            workflow.connect_nodes(pause_node, downstream)
+            # 2. Simulate an executor that handles a database constraint error.
+            def handle_database_error(_node, _input_data):
+                try:
+                    User.objects.create(username=self.user.username)
+                except IntegrityError as error:
+                    return {
+                        "status": "error",
+                        "error_message": str(error),
+                    }
 
-            # 2. Record whether the downstream executor runs inside an atomic block.
-            atomic_states = []
-            original_execute = WorkflowNode.execute
-
-            def capture_transaction_state(node, input_data):
-                atomic_states.append(transaction.get_connection().in_atomic_block)
-                return original_execute(node, input_data)
-
-            with patch.object(WorkflowNode, "execute", new=capture_transaction_state):
+            with patch.object(WorkflowNode, "execute", new=handle_database_error):
+                # 3. Resume the workflow without poisoning its outer transaction.
                 resumed_run = resume_workflow(paused_step)
 
-            # 3. Verify execution happens after the claim transaction commits.
-            self.assertEqual(atomic_states, [False])
-            self.assertTrue(resumed_run.execution_trace[-1]["output"]["approved"])
+            # 4. Verify the handled error and completed resume are persisted.
+            paused_step.refresh_from_db()
+            self.assertEqual(paused_step.status, "COMPLETED")
+            self.assertEqual(
+                resumed_run.execution_trace[-1]["output"]["status"],
+                "error",
+            )
 
-    def test_async_resume_executes_nodes_after_lock_transaction_commits(self):
+    def test_async_resume_recovers_from_handled_database_error(self):
         """
-        Use case: Celery resumes an asynchronous workflow after a paused step.
-        Expected result: Downstream nodes execute outside the transaction used to claim the step.
+        Use case: Celery resumes a node that handles a database error as workflow output.
+        Expected result: The task completes without breaking the workflow resume transaction.
         """
         # 1. Create an asynchronous workflow run with a step that can be resumed.
-        workflow = Workflow.objects.create(
-            name="Async resume transaction boundary",
-            enable_logging=True,
-            run_asynchronously=True,
-        )
-        trigger = WorkflowNode.objects.create(
-            workflow=workflow,
-            sub_type="HUMAN_TRIGGER",
-            parameters={"data": {"proposal": "ready"}},
-            type="TRIGGER",
-        )
-        pause_node = WorkflowNode.objects.create(
-            workflow=workflow,
-            sub_type="ENRICH_DATA",
-            parameters={"data": {}},
-            type="ACTION",
-        )
-        workflow.connect_nodes(trigger, pause_node)
-
         with tempfile.TemporaryDirectory() as media_root, self.settings(MEDIA_ROOT=media_root):
-            workflow_run = run_workflow_sync(workflow, {})
-            paused_step = workflow_run.steps.get(sequence=1)
-            paused_step.status = "PAUSED"
-            paused_step.save(update_fields=["status"])
-
-            downstream = WorkflowNode.objects.create(
-                workflow=workflow,
-                sub_type="ENRICH_DATA",
-                parameters={"data": {"approved": True}},
-                type="ACTION",
+            workflow_run, paused_step = self._create_resumable_workflow(
+                run_asynchronously=True,
             )
-            workflow.connect_nodes(pause_node, downstream)
 
-            # 2. Run the Celery task directly and record the executor transaction state.
-            atomic_states = []
-            original_execute = WorkflowNode.execute
+            # 2. Simulate an executor that handles a database constraint error.
+            def handle_database_error(_node, _input_data):
+                try:
+                    User.objects.create(username=self.user.username)
+                except IntegrityError as error:
+                    return {
+                        "status": "error",
+                        "error_message": str(error),
+                    }
 
-            def capture_transaction_state(node, input_data):
-                atomic_states.append(transaction.get_connection().in_atomic_block)
-                return original_execute(node, input_data)
-
-            with patch.object(WorkflowNode, "execute", new=capture_transaction_state):
+            with patch.object(WorkflowNode, "execute", new=handle_database_error):
+                # 3. Run the Celery task directly.
                 result = resume_workflow_async.run(paused_step.pk)
 
-            # 3. Verify the task completed after executing outside the claim transaction.
-            self.assertEqual(atomic_states, [False])
+            # 4. Verify the async resume completed and persisted its handled error.
+            paused_step.refresh_from_db()
+            completed_step = workflow_run.steps.order_by("-sequence").first()
+            self.assertEqual(paused_step.status, "COMPLETED")
+            self.assertEqual(completed_step.status, "COMPLETED")
+            with completed_step.output_file.open("r") as output_file:
+                self.assertEqual(json.load(output_file)["status"], "error")
             self.assertEqual(result["workflow_run_id"], str(workflow_run.id))
+
+    def test_resume_workflow_rolls_back_completion_after_unhandled_error(self):
+        """
+        Use case: A downstream node raises while a paused workflow is being resumed.
+        Expected result: The paused step remains retryable and no successor step is committed.
+        """
+        # 1. Create a workflow run with a step that can be resumed.
+        with tempfile.TemporaryDirectory() as media_root, self.settings(MEDIA_ROOT=media_root):
+            workflow_run, paused_step = self._create_resumable_workflow()
+
+            # 2. Fail the downstream executor during the resume transaction.
+            with patch.object(
+                WorkflowNode,
+                "execute",
+                side_effect=ValueError("Downstream execution failed"),
+            ):
+                with self.assertRaisesRegex(ValueError, "Downstream execution failed"):
+                    resume_workflow(paused_step)
+
+            # 3. Verify the completion and failed successor step were rolled back.
+            paused_step.refresh_from_db()
+            self.assertEqual(paused_step.status, "PAUSED")
+            self.assertEqual(workflow_run.steps.count(), 2)
 
     def test_run_workflow_can_start_from_a_selected_node(self):
         workflow = Workflow.objects.create(name="Debug start workflow")

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.15.14"
+version = "1.15.15"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## To-do

- Branch: `todo/98b1-bug-approve-workflow`
- Title: `[BUG] Approve workflow`
- Identifier: suffix `98b1` (the full to-do UUID was not available from the configured API queue)

## Summary

- keep paused-step completion and downstream execution in the same atomic resume transaction
- isolate each executor in a nested savepoint when workflow execution is already atomic
- preserve explicit executor error output when PostgreSQL reports an aborted transaction while releasing that savepoint
- roll back an unhandled continuation failure so the approval remains `PAUSED` and retryable
- report asynchronous approval as queued instead of prematurely resumed
- cover synchronous approval, direct Celery resume, handled database errors, PostgreSQL savepoint failure, rollback behavior, and the async UI response

## Verification

- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache .venv/bin/python -m py_compile bloomerp/services/workflow_services.py bloomerp/components/automation/approve_workflow_continuation.py bloomerp/tests/automation/test_automation.py bloomerp/tests/components/automation/test_approve_workflow_continuation_component.py` — passed
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache .venv/bin/python manage.py check` — passed with existing third-party model warnings
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache .venv/bin/python manage.py test bloomerp.tests.automation.test_automation.TestAutomation.test_resume_workflow_continues_existing_run_from_saved_step bloomerp.tests.automation.test_automation.TestAutomation.test_resume_workflow_dispatches_asynchronously_for_async_workflow bloomerp.tests.automation.test_automation.TestAutomation.test_resume_workflow_recovers_from_handled_database_error bloomerp.tests.automation.test_automation.TestAutomation.test_execute_node_recovers_output_after_aborted_savepoint bloomerp.tests.automation.test_automation.TestAutomation.test_async_resume_recovers_from_handled_database_error bloomerp.tests.automation.test_automation.TestAutomation.test_resume_workflow_rolls_back_completion_after_unhandled_error bloomerp.tests.automation.test_automation.TestAutomation.test_flow_object_human_in_the_loop_pauses_when_arrived bloomerp.tests.components.automation.test_approve_workflow_continuation_component` — 10 tests passed
- The full automation module was run before the review revision: 65 tests ran, with 52 passing and 13 unrelated existing create/update/condition/API failures. The final focused suite above was rerun after the revision.

## To-do update

The configured to-do API did not return the item whose UUID ends in `98b1`, so assignment and the `in_review` status update could not be performed without guessing the full UUID.
