### PR TITLE
[BUG] Recover handled PostgreSQL workflow errors

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/components/automation/approve_workflow_continuation.py
+++ b/bloomerp/django_bloomerp/bloomerp/components/automation/approve_workflow_continuation.py
@@ -89,14 +89,18 @@ def approve_workflow_continuation(request: HttpRequest, workflow_run_id: str) ->
                 type="info"
             )
         
-        resume_workflow(
+        resumed_workflow = resume_workflow(
             paused_step,
             output_data=form.cleaned_data.get("data") or output_step_data
         )
         
         return render_page_refresh_with_message(
             request,
-            message="Workflow resumed",
+            message=(
+                "Workflow resumed"
+                if resumed_workflow is not None
+                else "Workflow resume queued"
+            ),
             type="info"
         )
     

--- a/bloomerp/django_bloomerp/bloomerp/services/workflow_services.py
+++ b/bloomerp/django_bloomerp/bloomerp/services/workflow_services.py
@@ -23,6 +23,7 @@ from bloomerp.utils.json_serialization import make_json_safe
 
 
 _NO_OUTPUT = object()
+_IN_FAILED_SQL_TRANSACTION = "25P02"
 
 
 class _WorkflowPaused(Exception):
@@ -246,6 +247,14 @@ def load_step_output(step: WorkflowRunStep) -> dict | Any:
         )
 
 
+def _is_in_failed_sql_transaction(error: DatabaseError) -> bool:
+    database_error = error.__cause__
+    return (
+        getattr(database_error, "sqlstate", None) == _IN_FAILED_SQL_TRANSACTION
+        or getattr(database_error, "pgcode", None) == _IN_FAILED_SQL_TRANSACTION
+    )
+
+
 def _execute_node(node: WorkflowNode, input_data: object) -> object:
     """Execute a node without allowing a handled database error to break its caller."""
     if not transaction.get_connection().in_atomic_block:
@@ -255,12 +264,12 @@ def _execute_node(node: WorkflowNode, input_data: object) -> object:
     try:
         with transaction.atomic():
             output_data = node.execute(input_data)
-    except DatabaseError:
+    except DatabaseError as error:
         is_handled_error = (
             isinstance(output_data, dict)
             and output_data.get("status") == "error"
         )
-        if not is_handled_error:
+        if not is_handled_error or not _is_in_failed_sql_transaction(error):
             raise
 
     return output_data

--- a/bloomerp/django_bloomerp/bloomerp/services/workflow_services.py
+++ b/bloomerp/django_bloomerp/bloomerp/services/workflow_services.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from django.apps import apps
 from django.core.files.base import ContentFile
-from django.db import transaction
+from django.db import DatabaseError, transaction
 from django.db.models import Max, Model
 from django.db.models.query import QuerySet
 from django.utils import timezone
@@ -244,6 +244,26 @@ def load_step_output(step: WorkflowRunStep) -> dict | Any:
         return _deserialize_trigger_data(
             json.loads(output_file.read().decode("utf-8"))
         )
+
+
+def _execute_node(node: WorkflowNode, input_data: object) -> object:
+    """Execute a node without allowing a handled database error to break its caller."""
+    if not transaction.get_connection().in_atomic_block:
+        return node.execute(input_data)
+
+    output_data = _NO_OUTPUT
+    try:
+        with transaction.atomic():
+            output_data = node.execute(input_data)
+    except DatabaseError:
+        is_handled_error = (
+            isinstance(output_data, dict)
+            and output_data.get("status") == "error"
+        )
+        if not is_handled_error:
+            raise
+
+    return output_data
 
 def _replace_step_output(step: WorkflowRunStep, output_data) -> None:
     serialized_output = _serialize_trigger_data(output_data)
@@ -509,13 +529,7 @@ def _execute_workflow_state(
             state.scope_key = parent_scope
         
         try:
-            if transaction.get_connection().in_atomic_block:
-                # Some executors convert database errors into workflow output.
-                # Isolate them so the surrounding workflow transaction remains usable.
-                with transaction.atomic():
-                    output_data = node.execute(input_data)
-            else:
-                output_data = node.execute(input_data)
+            output_data = _execute_node(node, input_data)
         except Exception as error:
             _trace_node(execution_trace, node, "error", error=error)
             _create_run_step(

--- a/bloomerp/django_bloomerp/bloomerp/tests/automation/test_automation.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/automation/test_automation.py
@@ -373,13 +373,17 @@ class TestAutomation(TransactionTestCase):
             "error_message": "Invalid configured query",
         }
         connection = Mock(in_atomic_block=True)
+        postgres_error = Exception("current transaction is aborted")
+        postgres_error.sqlstate = "25P02"
+        aborted_transaction = DatabaseError("current transaction is aborted")
+        aborted_transaction.__cause__ = postgres_error
 
         class AbortedSavepoint:
             def __enter__(self):
                 return self
 
             def __exit__(self, exc_type, exc_value, traceback):
-                raise DatabaseError("current transaction is aborted")
+                raise aborted_transaction
 
         # 2. Execute through the failed savepoint boundary reported by PostgreSQL.
         with (
@@ -397,6 +401,43 @@ class TestAutomation(TransactionTestCase):
         # 3. Verify the executor's handled error remains available to the workflow.
         self.assertEqual(output["status"], "error")
         self.assertEqual(output["error_message"], "Invalid configured query")
+
+    def test_execute_node_reraises_unrelated_savepoint_database_error(self):
+        """
+        Use case: Savepoint release fails for a reason unrelated to an aborted transaction.
+        Expected result: The database failure is not hidden by an executor error result.
+        """
+        # 1. Simulate an executor error result followed by an unrelated connection failure.
+        node = Mock()
+        node.execute.return_value = {
+            "status": "error",
+            "error_message": "Invalid configured query",
+        }
+        connection = Mock(in_atomic_block=True)
+        connection_error = DatabaseError("server closed the connection unexpectedly")
+
+        class FailedSavepoint:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                raise connection_error
+
+        # 2. Verify that only PostgreSQL's aborted-transaction error is recoverable.
+        with (
+            patch(
+                "bloomerp.services.workflow_services.transaction.get_connection",
+                return_value=connection,
+            ),
+            patch(
+                "bloomerp.services.workflow_services.transaction.atomic",
+                return_value=FailedSavepoint(),
+            ),
+            self.assertRaises(DatabaseError) as raised,
+        ):
+            _execute_node(node, {})
+
+        self.assertIs(raised.exception, connection_error)
 
     def test_async_resume_recovers_from_handled_database_error(self):
         """

--- a/bloomerp/django_bloomerp/bloomerp/tests/automation/test_automation.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/automation/test_automation.py
@@ -1,9 +1,9 @@
 import json
 import tempfile
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.contrib.contenttypes.models import ContentType
-from django.db import IntegrityError, models
+from django.db import DatabaseError, IntegrityError, models
 from django.test import TransactionTestCase
 from django_celery_beat.models import PeriodicTask
 from regex import F
@@ -24,6 +24,7 @@ from bloomerp.celery.tasks.workflow_task import (
     run_workflow_async,
 )
 from bloomerp.services.workflow_services import (
+    _execute_node,
     _serialize_trigger_data,
     format_execution_trace,
     resume_workflow,
@@ -359,6 +360,43 @@ class TestAutomation(TransactionTestCase):
                 resumed_run.execution_trace[-1]["output"]["status"],
                 "error",
             )
+
+    def test_execute_node_recovers_output_after_aborted_savepoint(self):
+        """
+        Use case: PostgreSQL detects a swallowed database error when committing a savepoint.
+        Expected result: Explicit error output is preserved after the savepoint is rolled back.
+        """
+        # 1. Simulate an executor returning an explicit error before savepoint release fails.
+        node = Mock()
+        node.execute.return_value = {
+            "status": "error",
+            "error_message": "Invalid configured query",
+        }
+        connection = Mock(in_atomic_block=True)
+
+        class AbortedSavepoint:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                raise DatabaseError("current transaction is aborted")
+
+        # 2. Execute through the failed savepoint boundary reported by PostgreSQL.
+        with (
+            patch(
+                "bloomerp.services.workflow_services.transaction.get_connection",
+                return_value=connection,
+            ),
+            patch(
+                "bloomerp.services.workflow_services.transaction.atomic",
+                return_value=AbortedSavepoint(),
+            ),
+        ):
+            output = _execute_node(node, {})
+
+        # 3. Verify the executor's handled error remains available to the workflow.
+        self.assertEqual(output["status"], "error")
+        self.assertEqual(output["error_message"], "Invalid configured query")
 
     def test_async_resume_recovers_from_handled_database_error(self):
         """

--- a/bloomerp/django_bloomerp/bloomerp/tests/components/automation/test_approve_workflow_continuation_component.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/components/automation/test_approve_workflow_continuation_component.py
@@ -1,7 +1,8 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.contrib.auth.models import Group
 from django.http import HttpResponse
+from django.urls import reverse
 
 from bloomerp.models import User
 from bloomerp.models.automation import Workflow, WorkflowNode
@@ -109,3 +110,52 @@ class TestApproveWorkflowContinuationComponent(BloomerpComponentTestCase):
         self._prepare_component(setup)
         self.user.is_superuser = True
         self.user.save(update_fields=["is_superuser"])
+
+    def test_async_approval_reports_that_resume_was_queued(self):
+        """
+        Use case: An approver continues an asynchronous workflow.
+        Expected result: The response says the resume was queued instead of completed.
+        """
+        # 1. Configure the workflow and user for asynchronous approval.
+        self.workflow.run_asynchronously = True
+        self.workflow.save(update_fields=["run_asynchronously"])
+        self._set_approvers(users=[self.user.id])
+        self.client.force_login(self.user)
+        approval_form = Mock()
+        approval_form.is_valid.return_value = True
+        approval_form.cleaned_data = {"data": {}}
+
+        # 2. Submit approval while isolating the asynchronous dispatcher and response.
+        with (
+            patch(
+                "bloomerp.components.automation.approve_workflow_continuation.load_step_output",
+                return_value={},
+            ),
+            patch(
+                "bloomerp.components.automation.approve_workflow_continuation.ApproveWorkflowContinuationForm",
+                return_value=approval_form,
+            ),
+            patch(
+                "bloomerp.components.automation.approve_workflow_continuation.resume_workflow",
+                return_value=None,
+            ),
+            patch(
+                "bloomerp.components.automation.approve_workflow_continuation.render_page_refresh_with_message",
+                return_value=HttpResponse(),
+            ) as render_message,
+        ):
+            response = self.client.post(
+                reverse(
+                    self.view_name,
+                    kwargs={"workflow_run_id": self.workflow_run.id},
+                ),
+                {"data": "{}"},
+            )
+
+        # 3. Verify the UI reports queueing rather than premature completion.
+        self.assertEqual(response.status_code, 200)
+        render_message.assert_called_once()
+        self.assertEqual(
+            render_message.call_args.kwargs["message"],
+            "Workflow resume queued",
+        )

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.15.15"
+version = "1.15.16"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Context

Follow-up to #153 after production exposed a raw PostgreSQL error swallowed by a workflow node executor. PostgreSQL reports the transaction as aborted only when Django releases the nested savepoint, which caused async resume to roll back without persisting any new run steps.

## Summary

- preserve explicit `status: error` executor output after Django safely rolls back an aborted savepoint
- continue re-raising genuine or unhandled database failures so paused approvals remain retryable
- report asynchronous approval as `Workflow resume queued` instead of premature completion
- add coverage for the exact PostgreSQL savepoint-exit failure and async UI behavior

## Verification

- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache .venv/bin/python -m py_compile bloomerp/services/workflow_services.py bloomerp/components/automation/approve_workflow_continuation.py bloomerp/tests/automation/test_automation.py bloomerp/tests/components/automation/test_approve_workflow_continuation_component.py` — passed
- `PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache .venv/bin/python manage.py check` — passed with existing third-party model warnings
- focused approval/resume suite — 10 tests passed

## Configuration note

A downstream node configuration is still the likely source of the original database error. This change prevents that handled node error from corrupting the workflow transaction and persists its error output so the failing node/configuration can be identified from the run steps.
