### PR TITLE
Fix workflow code editor cleanup lifecycle

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/CodeEditorWidget.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/CodeEditorWidget.ts
@@ -16,10 +16,14 @@ export default class CodeEditorWidget extends BaseWidget {
     private boundOnModalClosed: ((event: Event) => void) | null = null;
     private boundOnTextareaInput: (() => void) | null = null;
     private destroyed: boolean = false;
+    private readonly boundOnBeforeCleanupElement = (event: Event): void => {
+        if (event.target === this.element) this.destroy();
+    };
     private readonly boundOnThemeChange = (): void => this.updateEditorTheme();
 
     public initialize(): void {
         if (!this.element) return;
+        this.element.addEventListener('htmx:beforeCleanupElement', this.boundOnBeforeCleanupElement);
         this.language = this.element.dataset.language || '';
         this.launchFromButton = this.element.dataset.launchFromButton === 'true';
         this.modalId = this.element.dataset.modalId || '';
@@ -110,6 +114,7 @@ export default class CodeEditorWidget extends BaseWidget {
         if (this.boundOnModalClosed) {
             document.body.removeEventListener('bloomerp:modal-closed', this.boundOnModalClosed);
         }
+        this.element?.removeEventListener('htmx:beforeCleanupElement', this.boundOnBeforeCleanupElement);
         window.removeEventListener('bloomerp:theme-change', this.boundOnThemeChange);
 
         if (this.textarea && this.boundOnTextareaInput) {

--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/workflows/Workflow.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/workflows/Workflow.ts
@@ -1567,7 +1567,6 @@ export default class Workflow extends BaseComponent {
             edit_mode: editMode,
         });
 
-        this.destroyNodeConfigCodeEditors(target);
         htmx.ajax(
             'get',
             `/components/automation/render_workflow_node/?${params.toString()}`,
@@ -1576,12 +1575,6 @@ export default class Workflow extends BaseComponent {
             this.prepareNodeConfigForm(target);
             initComponents(target);
             this.setupNodeConfigForm(target);
-        });
-    }
-
-    private destroyNodeConfigCodeEditors(container: HTMLElement): void {
-        container.querySelectorAll<HTMLElement>('[bloomerp-component="code-editor-widget"]').forEach((element) => {
-            getComponent(element)?.destroy();
         });
     }
 

--- a/bloomerp/django_bloomerp/bloomerp/tests/e2e/automation/test_workflow_code_editor_e2e.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/e2e/automation/test_workflow_code_editor_e2e.py
@@ -33,31 +33,54 @@ class TestWorkflowCodeEditorE2E(e2e.BloomerpE2ETestCase):
         node = self.page.locator("#drawflow .drawflow-node").first
         expect(node).to_be_visible()
 
-        for index, query in enumerate(("SELECT 2", "SELECT 3")):
-            with self.page.expect_response(
-                lambda response: "/components/automation/render_workflow_node/" in response.url
-            ):
-                node.dblclick()
+        editor = self.open_editor(node)
+        editor.evaluate(
+            "element => { window.__previousWorkflowWidget = "
+            "element.closest('[bloomerp-component]').__bloomerp_component; }"
+        )
+        self.replace_editor_value(editor, "SELECT 2")
+        self.close_editor()
 
-            editor = self.page.locator("[data-code-editor-container]")
-            expect(editor).to_be_visible()
-            self.page.wait_for_function(
-                "element => Boolean(element.env?.editor)",
-                arg=editor.element_handle(),
-            )
-            if index:
-                self.assertTrue(self.page.evaluate("window.__previousWorkflowWidget.destroyed"))
-            else:
-                editor.evaluate(
-                    "element => { window.__previousWorkflowWidget = "
-                    "element.closest('[bloomerp-component]').__bloomerp_component; }"
-                )
+        route_pattern = "**/components/automation/render_workflow_node/**"
+        self.page.route(route_pattern, lambda route: route.abort(), times=1)
+        with self.page.expect_event(
+            "requestfailed",
+            predicate=lambda request: "/components/automation/render_workflow_node/" in request.url,
+        ):
+            node.dblclick()
 
-            editor.click()
-            editor.evaluate("element => element.env.editor.selectAll()")
-            self.page.keyboard.type(query)
-            expect(self.page.locator("[data-code-editor-input]")).to_have_value(query)
+        editor = self.page.locator("[data-code-editor-container]")
+        expect(editor).to_be_visible()
+        self.assertFalse(self.page.evaluate("window.__previousWorkflowWidget.destroyed"))
+        self.replace_editor_value(editor, "SELECT 2 FROM failed_request")
+        self.close_editor()
 
-            modal = self.page.locator("#bloomerp-general-use-modal")
-            modal.locator('[bloomerp-close-modal="bloomerp-general-use-modal"]').click()
-            expect(modal).to_be_hidden()
+        editor = self.open_editor(node)
+        self.assertTrue(self.page.evaluate("window.__previousWorkflowWidget.destroyed"))
+        self.replace_editor_value(editor, "SELECT 3")
+        self.close_editor()
+
+    def open_editor(self, node):
+        with self.page.expect_response(
+            lambda response: "/components/automation/render_workflow_node/" in response.url
+        ):
+            node.dblclick()
+
+        editor = self.page.locator("[data-code-editor-container]")
+        expect(editor).to_be_visible()
+        self.page.wait_for_function(
+            "element => Boolean(element.env?.editor)",
+            arg=editor.element_handle(),
+        )
+        return editor
+
+    def replace_editor_value(self, editor, value):
+        editor.click()
+        editor.evaluate("element => element.env.editor.selectAll()")
+        self.page.keyboard.type(value)
+        expect(self.page.locator("[data-code-editor-input]")).to_have_value(value)
+
+    def close_editor(self):
+        modal = self.page.locator("#bloomerp-general-use-modal")
+        modal.locator('[bloomerp-close-modal="bloomerp-general-use-modal"]').click()
+        expect(modal).to_be_hidden()

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.15.19"
+version = "1.15.20"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/bloomerp/django_bloomerp/uv.lock
+++ b/bloomerp/django_bloomerp/uv.lock
@@ -232,7 +232,7 @@ wheels = [
 
 [[package]]
 name = "bloomerp"
-version = "1.15.17"
+version = "1.15.20"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
## Summary
- defer Ace editor teardown until HTMX removes the existing widget after a successful swap
- keep the current editor usable when loading a replacement form fails
- extend the workflow code-editor E2E coverage for failed and successful reloads
- bump the package version from 1.15.19 to 1.15.20 and synchronize uv.lock

## Verification
- npm run type-check
- uv lock --check
- uv run pytest bloomerp/tests/e2e/automation/test_workflow_code_editor_e2e.py -q --reuse-db --no-migrations