### PR TITLE
Fix workflow node editor autosave ownership

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/workflows/Workflow.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/workflows/Workflow.ts
@@ -1540,8 +1540,6 @@ export default class Workflow extends BaseComponent {
      * @param nodeId the ID of the double-clicked node
      */
     private async handleNodeDoubleClick(nodeId: number): Promise<void> {
-        this.editingNodeId = nodeId;
-        const nodeData = this.drawflow.getNodeFromId(nodeId);
         await this.flushAutosave();
         const persistedNodeData = this.drawflow.getNodeFromId(nodeId);
         if (!persistedNodeData?.data?.workflowNodeId) {
@@ -1557,11 +1555,16 @@ export default class Workflow extends BaseComponent {
         modal.setSize('full')
         modal.setPadding('p-0')
         modal.open()
-        this.loadNodeConfigFormForNode(persistedNodeData, modalBody);
+        this.loadNodeConfigFormForNode(nodeId, persistedNodeData, modalBody);
 
     }
 
-    private loadNodeConfigFormForNode(nodeData: any, target: HTMLElement, editMode: 'form' | 'json' = 'form'): void {
+    private loadNodeConfigFormForNode(
+        drawflowNodeId: number,
+        nodeData: any,
+        target: HTMLElement,
+        editMode: 'form' | 'json' = 'form',
+    ): void {
         const params = new URLSearchParams({
             node_id: String(nodeData.data.workflowNodeId),
             edit_mode: editMode,
@@ -1572,6 +1575,7 @@ export default class Workflow extends BaseComponent {
             `/components/automation/render_workflow_node/?${params.toString()}`,
             target,
         ).then(() => {
+            this.editingNodeId = drawflowNodeId;
             this.prepareNodeConfigForm(target);
             initComponents(target);
             this.setupNodeConfigForm(target);
@@ -1643,7 +1647,7 @@ export default class Workflow extends BaseComponent {
         if (!target) return;
 
         this.nodeFormEditMode = editMode;
-        this.loadNodeConfigFormForNode(persistedNodeData, target, editMode);
+        this.loadNodeConfigFormForNode(drawflowNodeId, persistedNodeData, target, editMode);
     }
 
     private scheduleNodeConfigSave(form: HTMLFormElement, refreshForm: boolean = false): void {

--- a/bloomerp/django_bloomerp/bloomerp/tests/e2e/automation/test_workflow_code_editor_e2e.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/e2e/automation/test_workflow_code_editor_e2e.py
@@ -8,13 +8,22 @@ from bloomerp.tests.base import e2e_test_case as e2e
 class TestWorkflowCodeEditorE2E(e2e.BloomerpE2ETestCase):
     def prepare_workflow(self):
         self.workflow = Workflow.objects.create(name="Code editor lifecycle")
-        WorkflowNode.objects.create(
+        self.first = WorkflowNode.objects.create(
             workflow=self.workflow,
             type="ACTION",
             sub_type="SQL_QUERY",
-            name="Query",
+            name="First query",
             parameters={"query": "SELECT 1", "page_size": 100},
             pos_x=0,
+            pos_y=0,
+        )
+        self.second = WorkflowNode.objects.create(
+            workflow=self.workflow,
+            type="ACTION",
+            sub_type="SQL_QUERY",
+            name="Second query",
+            parameters={"query": "SELECT 20", "page_size": 100},
+            pos_x=360,
             pos_y=0,
         )
 
@@ -30,15 +39,16 @@ class TestWorkflowCodeEditorE2E(e2e.BloomerpE2ETestCase):
         ]
 
     def reopen_code_editor(self):
-        node = self.page.locator("#drawflow .drawflow-node").first
-        expect(node).to_be_visible()
+        nodes = self.page.locator("#drawflow .drawflow-node")
+        expect(nodes).to_have_count(2)
+        first_node = nodes.filter(has_text="First query")
+        second_node = nodes.filter(has_text="Second query")
 
-        editor = self.open_editor(node)
+        editor = self.open_editor(first_node)
         editor.evaluate(
             "element => { window.__previousWorkflowWidget = "
             "element.closest('[bloomerp-component]').__bloomerp_component; }"
         )
-        self.replace_editor_value(editor, "SELECT 2")
         self.close_editor()
 
         route_pattern = "**/components/automation/render_workflow_node/**"
@@ -47,16 +57,26 @@ class TestWorkflowCodeEditorE2E(e2e.BloomerpE2ETestCase):
             "requestfailed",
             predicate=lambda request: "/components/automation/render_workflow_node/" in request.url,
         ):
-            node.dblclick()
+            second_node.dblclick()
 
         editor = self.page.locator("[data-code-editor-container]")
         expect(editor).to_be_visible()
         self.assertFalse(self.page.evaluate("window.__previousWorkflowWidget.destroyed"))
-        self.replace_editor_value(editor, "SELECT 2 FROM failed_request")
+        with self.page.expect_request(
+            lambda request: "/components/automation/save_workflow/" in request.url
+        ) as saved:
+            self.replace_editor_value(editor, "SELECT 2 FROM failed_request")
+
+        payload = saved.value.post_data_json
+        first_payload = next(node for node in payload["nodes"] if node.get("id") == self.first.pk)
+        second_payload = next(node for node in payload["nodes"] if node.get("id") == self.second.pk)
+        self.assertEqual(first_payload["parameters"]["query"], "SELECT 2 FROM failed_request")
+        self.assertEqual(second_payload["parameters"]["query"], "SELECT 20")
         self.close_editor()
 
-        editor = self.open_editor(node)
+        editor = self.open_editor(second_node)
         self.assertTrue(self.page.evaluate("window.__previousWorkflowWidget.destroyed"))
+        expect(self.page.locator("[data-code-editor-input]")).to_have_value("SELECT 20")
         self.replace_editor_value(editor, "SELECT 3")
         self.close_editor()
 

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.15.20"
+version = "1.15.21"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/bloomerp/django_bloomerp/uv.lock
+++ b/bloomerp/django_bloomerp/uv.lock
@@ -232,7 +232,7 @@ wheels = [
 
 [[package]]
 name = "bloomerp"
-version = "1.15.20"
+version = "1.15.21"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
## Summary
- update the active editing node only after its configuration form loads successfully
- keep a failed replacement request bound to the form and node that remain visible
- extend the code-editor E2E test to cover autosave ownership across two nodes
- bump the package version from 1.15.20 to 1.15.21 and sync uv.lock

## Verification
- `npm run type-check`
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache uv lock --check`
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run pytest bloomerp/tests/e2e/automation/test_workflow_code_editor_e2e.py -q --reuse-db --no-migrations`