### PR TITLE
Fix code editor reinitialization state

### DIFF
--- a/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/CodeEditorWidget.ts
+++ b/bloomerp/django_bloomerp/bloomerp/static_src/ts/components/widgets/CodeEditorWidget.ts
@@ -4,6 +4,7 @@ import { BaseWidget } from './BaseWidget';
 export default class CodeEditorWidget extends BaseWidget {
     private static readonly editorsByContainer = new WeakMap<HTMLElement, any>();
     private static readonly editorHostClassNames = ['ace_editor', 'ace_hidpi'];
+    private static readonly editorThemeClassNames = ['ace-chrome', 'ace-tomorrow-night', 'ace_dark'];
 
     private textarea: HTMLTextAreaElement | null = null;
     private editorContainer: HTMLElement | null = null;
@@ -275,15 +276,30 @@ export default class CodeEditorWidget extends BaseWidget {
         if (!this.editorContainer) return;
 
         this.editorContainer.classList.add(...CodeEditorWidget.editorHostClassNames);
+        this.restoreEditorThemeState();
         this.editorContainer.style.fontSize = '14px';
     }
 
     private updateEditorTheme(): void {
         if (!this.editor) return;
 
-        const theme = document.documentElement.classList.contains('dark')
+        const theme = this.isDarkTheme()
             ? 'ace/theme/tomorrow_night'
             : 'ace/theme/chrome';
         this.editor.setTheme(theme);
+        this.restoreEditorThemeState();
+    }
+
+    private restoreEditorThemeState(): void {
+        if (!this.editorContainer) return;
+
+        const isDark = this.isDarkTheme();
+        this.editorContainer.classList.remove(...CodeEditorWidget.editorThemeClassNames);
+        this.editorContainer.classList.add(isDark ? 'ace-tomorrow-night' : 'ace-chrome');
+        if (isDark) this.editorContainer.classList.add('ace_dark');
+    }
+
+    private isDarkTheme(): boolean {
+        return document.documentElement.classList.contains('dark');
     }
 }

--- a/bloomerp/django_bloomerp/bloomerp/tests/e2e/automation/test_workflow_code_editor_e2e.py
+++ b/bloomerp/django_bloomerp/bloomerp/tests/e2e/automation/test_workflow_code_editor_e2e.py
@@ -45,6 +45,7 @@ class TestWorkflowCodeEditorE2E(e2e.BloomerpE2ETestCase):
         second_node = nodes.filter(has_text="Second query")
 
         editor = self.open_editor(first_node)
+        self.assert_editor_theme_initialized(editor)
         editor.evaluate(
             "element => { window.__previousWorkflowWidget = "
             "element.closest('[bloomerp-component]').__bloomerp_component; }"
@@ -76,6 +77,7 @@ class TestWorkflowCodeEditorE2E(e2e.BloomerpE2ETestCase):
 
         editor = self.open_editor(second_node)
         self.assertTrue(self.page.evaluate("window.__previousWorkflowWidget.destroyed"))
+        self.assert_editor_theme_initialized(editor)
         expect(self.page.locator("[data-code-editor-input]")).to_have_value("SELECT 20")
         self.replace_editor_value(editor, "SELECT 3")
         self.close_editor()
@@ -99,6 +101,14 @@ class TestWorkflowCodeEditorE2E(e2e.BloomerpE2ETestCase):
         editor.evaluate("element => element.env.editor.selectAll()")
         self.page.keyboard.type(value)
         expect(self.page.locator("[data-code-editor-input]")).to_have_value(value)
+
+    def assert_editor_theme_initialized(self, editor):
+        self.assertTrue(
+            editor.evaluate(
+                "element => element.classList.contains('ace-chrome') || "
+                "element.classList.contains('ace-tomorrow-night')"
+            )
+        )
 
     def close_editor(self):
         modal = self.page.locator("#bloomerp-general-use-modal")

--- a/bloomerp/django_bloomerp/pyproject.toml
+++ b/bloomerp/django_bloomerp/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "Bloomerp"
-version = "1.15.22"
+version = "1.15.23"
 description = "Bloomerp is an open-source Business Management Software framework that lets you create fully functional business management applications just by defining your Django database models."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/bloomerp/django_bloomerp/uv.lock
+++ b/bloomerp/django_bloomerp/uv.lock
@@ -232,7 +232,7 @@ wheels = [
 
 [[package]]
 name = "bloomerp"
-version = "1.15.21"
+version = "1.15.23"
 source = { editable = "." }
 dependencies = [
     { name = "annotated-types" },


### PR DESCRIPTION
## Summary
- restore the active Ace theme classes whenever a code editor host is initialized or restored
- keep light and dark editor state deterministic across HTMX replacement lifecycles
- assert theme initialization before and after reopening the workflow editor
- bump Bloomerp from 1.15.22 to 1.15.23 and sync uv.lock

## Verification
- `npm run type-check`
- `npm run build`
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache uv lock --check`
- `UV_CACHE_DIR=/tmp/bloomerp-uv-cache PYTHONPYCACHEPREFIX=/private/tmp/bloomerp-pycache uv run pytest bloomerp/tests/e2e/automation/test_workflow_code_editor_e2e.py -q --reuse-db --no-migrations`
- live browser validation: open, edit, close, reopen, edit; reopened editor retained its theme classes and synchronized its textarea value